### PR TITLE
Fix state-space explosion due to stale wakeups

### DIFF
--- a/traceforge/src/cons.rs
+++ b/traceforge/src/cons.rs
@@ -78,7 +78,7 @@ impl Consistency {
             // slab is not read, or is read by rlab s.t. (rlab1, rlab) in porf
             if slab
                 .reader()
-                .is_none_or(|rlab| g.in_porf(rlab1.pos(), rlab))
+                .map_or(true, |rlab| g.in_porf(rlab1.pos(), rlab))
             {
                 seen.push(slab.pos());
                 if Self::aux_send_before(g, slab.pos(), slab2, seen) {
@@ -123,7 +123,7 @@ impl Consistency {
                     // Exclude the receive itself
                     reader != rpos
                         && reader.thread == rpos.thread
-                        && view.is_none_or(|view| view.0.contains(reader))
+                        && view.map_or(true, |view| view.0.contains(reader))
                 })
             } else {
                 // there is no reader, or the reader is *not* in the view (we exclude the receive itself)

--- a/traceforge/src/cons.rs
+++ b/traceforge/src/cons.rs
@@ -1,7 +1,7 @@
 use crate::event::Event;
 use crate::event_label::{AsEventLabel, LabelEnum, RecvMsg, SendMsg};
 use crate::exec_graph::ExecutionGraph;
-use crate::loc::CommunicationModel;
+use crate::loc::{CommunicationModel, WakeMsg};
 use crate::revisit::Revisit;
 use crate::vector_clock::VectorClock;
 
@@ -192,7 +192,12 @@ impl Consistency {
         check_concurrent: bool,
     ) -> Vec<Event> {
         // Sends that the receive can read from
-        let sends = g.matching_stores(recv.recv_loc());
+        let sends = g.matching_stores(recv.recv_loc())
+            // filter-out WakeMsg in our porf prefix: the respective futures were cancelled
+            .filter(|&s| {
+                // cached_porf to disregard own rf (porf;po prefix)
+                !recv.cached_porf().contains(s.pos()) || s.val().as_any().downcast::<WakeMsg>().is_err()
+            });
 
         // Keep those that will exist and be unread after the revisit, checking
         // for concurrent receives.

--- a/traceforge/src/cons.rs
+++ b/traceforge/src/cons.rs
@@ -1,7 +1,7 @@
 use crate::event::Event;
 use crate::event_label::{AsEventLabel, LabelEnum, RecvMsg, SendMsg};
 use crate::exec_graph::ExecutionGraph;
-use crate::loc::{CommunicationModel, WakeMsg};
+use crate::loc::CommunicationModel;
 use crate::revisit::Revisit;
 use crate::vector_clock::VectorClock;
 
@@ -194,10 +194,7 @@ impl Consistency {
         // Sends that the receive can read from
         let sends = g.matching_stores(recv.recv_loc())
             // filter-out WakeMsg in our porf prefix: the respective futures were cancelled
-            .filter(|&s| {
-                // cached_porf to disregard own rf (porf;po prefix)
-                !recv.cached_porf().contains(s.pos()) || s.val().as_any().downcast::<WakeMsg>().is_err()
-            });
+            .filter(|&s| {!s.is_cancelled_wrt(recv.as_event_label())});
 
         // Keep those that will exist and be unread after the revisit, checking
         // for concurrent receives.

--- a/traceforge/src/event_label.rs
+++ b/traceforge/src/event_label.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::ops::RangeInclusive;
 
 use crate::event::Event;
-use crate::loc::{CommunicationModel, Loc, RecvLoc, SendLoc};
+use crate::loc::{CommunicationModel, Loc, RecvLoc, SendLoc, WakeMsg};
 use crate::msg::Val;
 use crate::thread::main_thread_id;
 use crate::vector_clock::VectorClock;
@@ -894,6 +894,10 @@ impl SendMsg {
         self.reader().is_none()
     }
 
+    pub(crate) fn is_cancelled_wrt(&self, other: &EventLabel) -> bool {
+        // cached_porf to disregard own rf (porf;po prefix)
+        self.val.as_any().downcast::<WakeMsg>().is_ok() && other.cached_porf().contains(self.pos())
+    }
     pub(crate) fn can_be_read_from(&self, reader_loc: &RecvLoc) -> bool {
         self.is_unread() && reader_loc.matches(self)
     }

--- a/traceforge/src/future/mod.rs
+++ b/traceforge/src/future/mod.rs
@@ -112,7 +112,7 @@ where
                 } else {
                     // Futured informed us to poll again
                     assert!(ind == 1);
-                    assert!(msg.as_any().downcast::<()>().is_ok());
+                    assert!(msg.as_any().downcast::<WakeMsg>().is_ok());
                     res = fut.as_mut().poll(&mut Context::from_waker(&fut_waker));
                 }
             };

--- a/traceforge/src/loc.rs
+++ b/traceforge/src/loc.rs
@@ -6,6 +6,10 @@ use crate::{
 
 use std::fmt::{Debug, Display};
 
+// Distinct unit type for async logic
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct WakeMsg;
+
 #[derive(Clone, Copy, Default, Debug, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub enum CommunicationModel {
     // A receive can read from any matching unread send

--- a/traceforge/src/must.rs
+++ b/traceforge/src/must.rs
@@ -718,7 +718,9 @@ impl Must {
                     send.can_be_monitor_read(&blab.pos()) ||
                     // . Plain read from the send:
                     // . . It is unread and the location *really* matches (not via monitoring)
-                        send.can_be_read_from(loc)
+                        (send.can_be_read_from(loc) &&
+                            // disregard cancelled sends
+                            !send.is_cancelled_wrt(&blab.as_event_label()))
                 })
             } else {
                 false

--- a/traceforge/tests/crash.rs
+++ b/traceforge/tests/crash.rs
@@ -51,7 +51,7 @@ enum ReplicaMsg {
     Terminate,
 }
 
-fn replica(pid: ThreadId, sid: ThreadId) {
+fn _replica(pid: ThreadId, sid: ThreadId) {
     let mut state = Replica {
         primary: pid,
         secondary: sid,
@@ -98,7 +98,7 @@ fn primary_node() -> () {
     let mut acked: HashMap<u32, u32> = HashMap::new();
     let mut txid: u32 = 0;
 
-    let (_pid, sid, sbyid) = initialize(Role::Primary);
+    let (_pid, sid, _sbyid) = initialize(Role::Primary);
 
     loop {
         let m = recv_msg_block();
@@ -155,7 +155,7 @@ fn secondary_node() -> () {
     let mut buffer: HashMap<u32, u32> = HashMap::new();
     let mut txid = 0;
 
-    let (pid, _sid, sbyid) = initialize(Role::Backup);
+    let (pid, _sid, _sbyid) = initialize(Role::Backup);
     loop {
         let m = recv_msg_block();
         match m {

--- a/traceforge/tests/microbenchmarks.rs
+++ b/traceforge/tests/microbenchmarks.rs
@@ -125,12 +125,12 @@ fn ns_r_sel_mk() {
     enum Msg {
         Val(thread::ThreadId, u32),
 
-        TID(thread::ThreadId),
+        _TID(thread::ThreadId),
     }
 
     let n: u32 = 8;
 
-    let mode = ConsType::WB;
+    let mode = ConsType::FIFO;
 
     let now = Instant::now();
 
@@ -211,12 +211,12 @@ fn ns_rn_mk() {
     enum Msg {
         Val(thread::ThreadId, u32),
 
-        TID(thread::ThreadId),
+        _TID(thread::ThreadId),
     }
 
     let n: u32 = 8;
 
-    let mode = ConsType::WB;
+    let mode = ConsType::FIFO;
 
     let now = Instant::now();
 


### PR DESCRIPTION
## Issue
The way it's currently implemented, when a Future is cancelled, it might have already sent some messages to the polling thread's top-level channel (see `block_on` in `future/mod.rs`) by means of calling the `wake` on the provided `Waker`.
When the polling thread later polls another Future, it can observe these stale messages, explore their ordering and
significantly increasing the number of executions.

# Fix
This PR fixes the issue by having a receive disregard Waker-related messages if the send has happened before (in a porf sense) and is thus either already consumed or originating from a cancelled Future.
Relevant stress tests are also added.