### PR TITLE
Adding named nondet choices, coverage information disabled by default

### DIFF
--- a/traceforge/src/event_label.rs
+++ b/traceforge/src/event_label.rs
@@ -984,6 +984,7 @@ impl fmt::Display for Unique {
 pub(crate) struct CToss {
     label: EventLabel,
     result: bool,
+    predetermined: bool,
 }
 
 impl CToss {
@@ -991,6 +992,7 @@ impl CToss {
         Self {
             label: EventLabel::new(pos),
             result: Self::maximal(),
+            predetermined: false,
         }
     }
 
@@ -1000,6 +1002,14 @@ impl CToss {
 
     pub(crate) fn set_result(&mut self, result: bool) {
         self.result = result
+    }
+
+    pub(crate) fn set_predetermined(&mut self) {
+        self.predetermined = true;
+    }
+
+    pub(crate) fn is_predetermined(&self) -> bool {
+        self.predetermined
     }
 
     pub(crate) fn maximal() -> bool {

--- a/traceforge/src/exec_graph.rs
+++ b/traceforge/src/exec_graph.rs
@@ -382,6 +382,42 @@ impl ExecutionGraph {
         self.get_thr(&t).tclab.daemon()
     }
 
+    /// Check if this execution graph represents a blocked execution.
+    /// Returns the BlockType if blocked, None if all threads completed normally.
+    /// Daemon threads are only skipped for Value blocks.
+    pub(crate) fn check_blocked(&self) -> Option<BlockType> {
+        let mut ret = None;
+        for t in self.thread_ids() {
+            if self.is_thread_blocked(t) {
+                let blab = self.thread_last(t).unwrap();
+                match blab {
+                    LabelEnum::Block(b) => match b.btype() {
+                        BlockType::Assume => {
+                            return Some(BlockType::Assume);
+                        }
+                        BlockType::Assert => {
+                            return Some(BlockType::Assert);
+                        }
+                        BlockType::Value(loc) => {
+                            if self.is_thread_daemon(t) {
+                                continue;
+                            } else {
+                                ret = Some(BlockType::Value(loc.clone()));
+                            }
+                        }
+                        block => {
+                            ret = Some(block.clone());
+                        }
+                    },
+                    _ => panic!("Blocked thread has unexpected last label {}", blab),
+                }
+            }
+        }
+        ret
+    }
+	 
+	
+
     /// Add a label to the graph, giving it a new stamp if it does not have one.
     pub(crate) fn add_label(&mut self, lab: LabelEnum) -> Event {
         self.add(lab).pos()

--- a/traceforge/src/lib.rs
+++ b/traceforge/src/lib.rs
@@ -45,10 +45,11 @@ use runtime::failure::persist_task_failure;
 use runtime::thread::continuation::{ContinuationPool, CONTINUATION_POOL};
 use runtime::thread::switch;
 
-use log::{info, trace};
+use log::{info, trace, debug};
 use serde::{Deserialize, Serialize};
 use smallvec::alloc::sync::Arc;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::future::Future;
 use std::iter;
 use std::rc::Rc;
@@ -202,6 +203,8 @@ pub struct Config {
     pub(crate) turmoil_trace_file: Option<String>,
     pub(crate) parallel: bool,
     pub(crate) parallel_workers: Option<usize>,
+    pub(crate) keep_per_execution_coverage: bool,
+    pub(crate) predetermined_choices: HashMap<String, Vec<Vec<bool>>>,    
     #[serde(skip)]
     pub(crate) callbacks: Arc<Mutex<Vec<Box<dyn ExecutionObserver + Send>>>>,
 }
@@ -262,6 +265,8 @@ impl ConfigBuilder {
             turmoil_trace_file: None,
             parallel: false,
             parallel_workers: None,
+            keep_per_execution_coverage: false,
+	        predetermined_choices: HashMap::new(),
             callbacks: Arc::new(Mutex::new(Vec::new())),
         })
     }
@@ -450,6 +455,39 @@ impl ConfigBuilder {
             .push(cb);
         self
     }
+
+    /// Enables storing per-execution coverage data across all executions.
+    /// When disabled (default), only the aggregate coverage and current execution coverage
+    /// (for ExecutionObserver callbacks) are kept, significantly reducing memory usage.
+    /// Enable this only if you need to query coverage for specific past executions.
+    pub fn with_keep_per_execution_coverage(mut self, keep: bool) -> Self {
+        self.0.keep_per_execution_coverage = keep;
+        self
+    }
+
+    /// Sets predetermined values for named nondeterministic choices.
+    ///
+    /// The map keys are choice names, and values are 2D vectors where:
+    /// - First dimension: thread index (0 = first thread to call this choice, 1 = second, etc.)
+    /// - Second dimension: occurrence within that thread (0 = first call, 1 = second, etc.)
+    ///
+    /// If a choice is not found in the map, or if indices are out of bounds,
+    /// the choice falls back to normal nondeterministic exploration.
+    ///
+    /// Example:
+    /// ```ignore
+    /// let mut choices = HashMap::new();
+    /// choices.insert("my_choice".to_string(), vec![
+    ///     vec![true, false, true],  // Thread 0: 1st=true, 2nd=false, 3rd=true
+    ///     vec![false, false],        // Thread 1: 1st=false, 2nd=false
+    /// ]);
+    /// Config::builder().with_predetermined_choices(choices).build()
+    /// ```
+    pub fn with_predetermined_choices(mut self, choices: HashMap<String, Vec<Vec<bool>>>) -> Self {
+        self.0.predetermined_choices = choices;
+        self
+    }
+	 
 
     /// Consumes the builder and produces the [`Config`]
     pub fn build(self) -> Config {
@@ -961,6 +999,143 @@ pub fn nondet() -> bool {
 pub fn coin_toss() -> bool {
     nondet()
 }
+
+/// Models a named nondeterministic boolean choice.
+///
+/// Named choices allow users to provide predetermined values via configuration,
+/// which can be useful for:
+/// - Reproducing specific behaviors
+/// - Directed testing
+/// - Reducing state space by fixing certain choices
+///
+/// If predetermined values are configured for this choice name, they will be used.
+/// Otherwise, the choice falls back to normal nondeterministic exploration.
+///
+/// Thread indices are assigned lazily (on first call to any named choice by that thread),
+/// so index 0 = first thread to use named choices, index 1 = second thread, etc.
+///
+/// # Example
+/// ```ignore
+/// use amzn_must::{named_nondet, Config};
+/// use std::collections::HashMap;
+///
+/// // Configure predetermined values
+/// let mut choices = HashMap::new();
+/// choices.insert("retry".to_string(), vec![
+///     vec![true, false, true],  // Thread 0: retry on 1st and 3rd attempts
+///     vec![false],               // Thread 1: don't retry
+/// ]);
+///
+/// amzn_must::verify(
+///     Config::builder()
+///         .with_predetermined_choices(choices)
+///         .build(),
+///     || {
+///         if named_nondet("retry") {
+///             // retry logic
+///         }
+///     }
+/// );
+/// ```
+pub fn named_nondet(name: &str) -> bool {
+    switch();
+    ExecutionState::with(|s| {
+        let pos = s.next_pos();
+        let thread_id = pos.thread;
+
+        let mut must = s.must.borrow_mut();
+
+        // Get thread index for this choice name with incremental freezing
+        // Each choice name has independent thread indexing
+        // Once a (choice_name, thread_id) pair is assigned an index, it's frozen for the entire exploration
+        let thread_idx = if let Some(name_map) = must.thread_index_map.get(name) {
+            if let Some(&idx) = name_map.get(&thread_id) {
+                // Already assigned (and frozen)
+                idx
+            } else {
+                // Thread not yet assigned for this choice name - assign and freeze immediately
+                let idx = *must.next_thread_index.get(name).unwrap_or(&0);
+                must.next_thread_index.insert(name.to_string(), idx + 1);
+
+                // Add to current execution mapping
+                must.thread_index_map
+                    .entry(name.to_string())
+                    .or_insert_with(HashMap::new)
+                    .insert(thread_id, idx);
+
+                // Immediately freeze this assignment for the rest of the exploration
+                if let Some(ref mut frozen) = must.frozen_thread_index_map {
+                    frozen
+                        .entry(name.to_string())
+                        .or_insert_with(HashMap::new)
+                        .insert(thread_id, idx);
+                    debug!(
+                        "Assigned and froze thread index {} to ThreadId {:?} for choice '{}'",
+                        idx, thread_id, name
+                    );
+                }
+
+                idx
+            }
+        } else {
+            // No mapping for this choice name yet - create and freeze immediately
+            let idx = 0;
+            must.next_thread_index.insert(name.to_string(), 1);
+
+            // Add to current execution mapping
+            let mut name_map = HashMap::new();
+            name_map.insert(thread_id, idx);
+            must.thread_index_map.insert(name.to_string(), name_map);
+
+            // Immediately freeze this assignment for the rest of the exploration
+            if let Some(ref mut frozen) = must.frozen_thread_index_map {
+                let mut frozen_name_map = HashMap::new();
+                frozen_name_map.insert(thread_id, idx);
+                frozen.insert(name.to_string(), frozen_name_map);
+                debug!(
+                    "Assigned and froze thread index {} to ThreadId {:?} for choice '{}'",
+                    idx, thread_id, name
+                );
+            }
+
+            idx
+        };
+
+        // Get and increment occurrence counter for this (name, thread_idx) pair
+        let occurrence = must
+            .choice_occurrence_counters
+            .entry((name.to_string(), thread_idx))
+            .or_insert(0);
+        let current_occurrence = *occurrence;
+        *occurrence += 1;
+
+        // Check if we have a predetermined value for this choice
+        let predetermined_value = must
+            .config
+            .predetermined_choices
+            .get(name)
+            .and_then(|thread_choices| thread_choices.get(thread_idx))
+            .and_then(|choices| choices.get(current_occurrence))
+            .copied();
+
+        if let Some(value) = predetermined_value {
+            debug!(
+                "Using predetermined value {} for choice '{}' [thread_idx={}, occurrence={}]",
+                value, name, thread_idx, current_occurrence
+            );
+            // Use handle_ctoss_predetermined which now handles both replay and handle modes
+            return must.handle_ctoss_predetermined(CToss::new(pos), value);
+        }
+
+        // Fallback to nondeterministic exploration (handles both replay and handle modes)
+        debug!(
+            "Using nondeterministic exploration for choice '{}' [thread_idx={}, occurrence={}]",
+            name, thread_idx, current_occurrence
+        );
+        must.handle_ctoss(CToss::new(pos))
+    })
+}
+	 
 
 use crate::monitor_types::{Monitor, MonitorResult};
 use std::ops::{Range, RangeInclusive};

--- a/traceforge/src/must.rs
+++ b/traceforge/src/must.rs
@@ -29,7 +29,7 @@ use crate::thread::{main_thread_id, ThreadId};
 
 use crate::monitor_types::{EndCondition, ExecutionEnd, Monitor, MonitorResult};
 use std::any::TypeId;
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fs::File;
 use std::io::Write;
 
@@ -121,6 +121,18 @@ pub(crate) struct Must {
     pub telemetry: Telemetry,
     published_values: BTreeMap<(ThreadId, TypeId), Val>,
     pub started_at: Instant,
+
+    // Named nondeterministic choice support
+    // Per-choice-name thread indexing: each choice name has independent thread indices
+    // Frozen mapping from first execution, used to ensure consistent thread indices across all executions
+    pub(crate) frozen_thread_index_map: Option<HashMap<String, HashMap<ThreadId, usize>>>,
+    // Current execution's mapping (built during first execution, then copied from frozen)
+    // Map: choice_name -> (ThreadId -> thread_idx)
+    pub(crate) thread_index_map: HashMap<String, HashMap<ThreadId, usize>>,
+    // Next available index for each choice name
+    pub(crate) next_thread_index: HashMap<String, usize>,
+    // Per-execution counters: (choice_name, thread_idx) -> occurrence count
+    pub(crate) choice_occurrence_counters: HashMap<(String, usize), usize>,
 }
 
 impl Must {
@@ -131,7 +143,7 @@ impl Must {
         {
             info!("Random schedule seed: {:?}", seed);
         }
-        let telemetry = Telemetry::default();
+        let telemetry = Telemetry::new(conf.keep_per_execution_coverage);
         let _ = telemetry.register_counter(&EXECS.to_owned());
         let _ = telemetry.register_counter(&BLOCKED.to_owned());
         let _ = telemetry.register_histogram(&EXECS_EST.to_owned());
@@ -150,6 +162,10 @@ impl Must {
             telemetry,
             published_values: BTreeMap::new(),
             started_at: Instant::now(),
+            frozen_thread_index_map: None,
+            thread_index_map: HashMap::new(),
+            next_thread_index: HashMap::new(),
+            choice_occurrence_counters: HashMap::new(),
         }
     }
 
@@ -167,6 +183,31 @@ impl Must {
         let mut must = must.borrow_mut();
         must.current.graph.initialize_for_execution();
         must.telemetry.coverage.new_eid();
+
+        // Reset per-execution state for named choices
+        // Initialize frozen mapping if not yet created (first execution)
+        if must.frozen_thread_index_map.is_none() {
+            must.frozen_thread_index_map = Some(HashMap::new());
+            debug!("Initialized empty frozen thread index mapping for incremental freezing");
+        }
+
+        // Restore from frozen mapping (which grows incrementally as threads are discovered)
+        let frozen_map = must.frozen_thread_index_map.as_ref().unwrap().clone();
+        must.thread_index_map = frozen_map.clone();
+        // Restore next_thread_index for each choice name
+        must.next_thread_index = frozen_map
+            .iter()
+            .map(|(name, map)| (name.clone(), map.len()))
+            .collect();
+
+        if !frozen_map.is_empty() {
+            let total_mappings: usize = frozen_map.values().map(|m| m.len()).sum();
+            debug!("Restored frozen thread index mapping for {} choice names with {} total thread mappings",
+                frozen_map.len(), total_mappings);
+        }
+
+        must.choice_occurrence_counters.clear();
+
         // TODO: when must is borrowed, the panic handler cannot capture
         // a counterexample. run_metrics_before() invokes must model code
         // that might panic, and it would be nice to refactor the code so that
@@ -528,6 +569,35 @@ impl Must {
         CToss::maximal()
     }
 
+    /// Handle a CToss with a predetermined value. Similar to handle_ctoss but does not add revisits.
+    pub(crate) fn handle_ctoss_predetermined(&mut self, mut ctlab: CToss, value: bool) -> bool {
+        if self.is_replay(ctlab.pos()) {
+            info!(
+                "| Replay Mode for {} with predetermined value {}",
+                ctlab, value
+            );
+            // In replay mode, validate the event exists and process it
+            ctlab.set_result(value);
+            ctlab.set_predetermined();
+            let lab = LabelEnum::CToss(ctlab);
+            self.current.graph.validate_replay_event(&lab);
+            self.process_event(lab);
+            // Return the predetermined value (ignoring what was in the graph)
+            return value;
+        }
+
+        info!(
+            "| Handle Mode for {} with predetermined value {}",
+            ctlab, value
+        );
+
+        ctlab.set_result(value);
+        ctlab.set_predetermined();
+        self.add_to_graph(LabelEnum::CToss(ctlab));
+        // Note: We don't add a revisit here because the value is predetermined
+        value
+    }    
+
     pub(crate) fn handle_choice(&mut self, chlab: Choice) -> usize {
         let result = chlab.result();
         let end = *chlab.range().end();
@@ -765,38 +835,7 @@ impl Must {
     /// Check if the execution is blocked. Return None if it's not blocked, or Some(Block)
     /// to tell why it is blocked.
     fn check_blocked(&mut self) -> Option<BlockType> {
-        for i in self.current.graph.thread_ids() {
-            if self.current.graph.is_thread_blocked(i) {
-                // find reason for block
-
-                // if the thread is daemon and blocked on a recv, mark it as "normal"
-
-                // if the thread is blocked on assume, print information on the execution
-                // otherwise raise an error (deadlock)
-
-                let blab = self.current.graph.thread_last(i).unwrap();
-                match blab {
-                    LabelEnum::Block(b) => {
-                        match b.btype() {
-                            BlockType::Value(loc) => {
-                                if self.current.graph.is_thread_daemon(i) {
-                                    // daemon threads can keep waiting on messages
-                                    debug!("Thread {i} is a daemon, keep going");
-                                    continue;
-                                } else {
-                                    return Some(BlockType::Value(loc.clone()));
-                                }
-                            }
-                            block => {
-                                return Some(block.clone());
-                            }
-                        }
-                    }
-                    _ => panic!("Blocked thread has unexpected last label {}", blab),
-                }
-            }
-        }
-        None
+        self.current.graph.check_blocked()    
     }
 
     /// `complete_execution` is invoked when a particular single execution has finished.
@@ -973,6 +1012,9 @@ impl Must {
                 self.telemetry.coverage.export_current().into(),
             );
         }
+
+        // Clean up per-execution coverage data after observers have been notified
+	    self.telemetry.coverage.cleanup_current_execution();
     }
 
     fn visit_rfs(&mut self, pos: Event, blocking: bool) -> Option<Val> {
@@ -1163,7 +1205,11 @@ impl Must {
     fn is_maximal(&self, lab: &LabelEnum, rev: &Revisit) -> bool {
         match lab {
             LabelEnum::RecvMsg(rlab) => self.is_maximal_recv(rlab, rev),
-            LabelEnum::CToss(ctlab) => ctlab.result() == CToss::maximal(),
+            // Predetermined CToss events are always maximal: they are not branching
+            // points, so no forward revisit exists to discover blocked backward revisits.
+            LabelEnum::CToss(ctlab) => {
+                ctlab.is_predetermined() || ctlab.result() == CToss::maximal()
+            }
             // Instead of checking if a send is read by a stamp-earlier receive,
             // we handle this via the revisitable flag on the corresponding receive.
             LabelEnum::SendMsg(slab) => !slab.is_dropped(),

--- a/traceforge/src/telemetry.rs
+++ b/traceforge/src/telemetry.rs
@@ -423,7 +423,7 @@ impl HistogramFn for Handle {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct Telemetry {
     inner: Arc<Mutex<HashMap<Key, Value>>>,
 
@@ -431,11 +431,11 @@ pub(crate) struct Telemetry {
 }
 
 impl Telemetry {
-    pub fn new() -> Self {
+    pub fn new(keep_per_execution_coverage: bool) -> Self {
         let hm: HashMap<Key, Value> = HashMap::new();
         Self {
             inner: Arc::new(Mutex::new(hm)),
-            coverage: CoverageTelemetry::new(),
+            coverage: CoverageTelemetry::new(keep_per_execution_coverage),
         }
     }
 
@@ -607,7 +607,7 @@ pub(crate) type ModuleFileLine = (&'static str, &'static str, u32);
     associated coverage information as well as the aggregate coverage and information about the execution id
 
 */
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct CoverageTelemetry {
     // per execution statistics about hitting a coverage goal
     perexec: Arc<Mutex<HashMap<ExecutionId, Coverage>>>,
@@ -619,15 +619,19 @@ pub(crate) struct CoverageTelemetry {
 
     // execution id generator for the must engine: each execution gets a unique id
     idgen: ExecutionIdGenerator,
+     
+    // whether to keep per-execution coverage data across all executions
+    keep_per_execution_coverage: bool,
 }
 
 impl CoverageTelemetry {
-    pub fn new() -> Self {
+    pub fn new(keep_per_execution_coverage: bool) -> Self {
         Self {
             perexec: Arc::new(Mutex::new(HashMap::new())),
             aggregate: Arc::new(Mutex::new(Coverage::new())),
             unique_table: Arc::new(Mutex::new(HashMap::new())),
             idgen: ExecutionIdGenerator::new(),
+            keep_per_execution_coverage,
         }
     }
 
@@ -819,11 +823,25 @@ impl CoverageTelemetry {
             Some(thistable) => thistable.clone(),
         }
     }
+
+    /// Cleans up the per-execution coverage data for the current execution if not configured to keep it.
+    /// This should be called after ExecutionObserver callbacks have been invoked.
+    pub fn cleanup_current_execution(&self) {
+        if !self.keep_per_execution_coverage {
+            let eid = self.current_eid();
+            let mut hm = self.perexec.lock().expect("Could not lock coverage table");
+            hm.remove(&eid);
+            debug!(
+                "Cleaned up per-execution coverage data for execution {}",
+                eid
+            );
+        }
+    }
 }
 
 #[test]
 fn cov_telemetry_basic() {
-    let mut cv = CoverageTelemetry::new();
+    let mut cv = CoverageTelemetry::new(true);
     let eid = cv.new_eid();
     cv.cover(eid, "B".to_owned(), std::module_path!(), "foo", 1);
     cv.cover(eid, "C".to_owned(), std::module_path!(), "foo", 2);

--- a/traceforge/src/testmode.rs
+++ b/traceforge/src/testmode.rs
@@ -56,7 +56,6 @@ pub fn test<F>(mut config: Config, f: F, samples: u64) -> f64
 where
     F: Fn() + Send + Sync + 'static,
 {
-    config.max_iterations = Some(1);
     config.schedule_policy = SchedulePolicy::Arbitrary;
 
     let f = Arc::new(f);

--- a/traceforge/tests/nondet.rs
+++ b/traceforge/tests/nondet.rs
@@ -1,5 +1,6 @@
-use traceforge::Nondet;
-use traceforge::{verify, Config};
+use traceforge::*;
+use traceforge::{thread, Nondet, Config};
+use std::collections::HashMap;
 
 #[test]
 fn test_nondet() {
@@ -17,4 +18,455 @@ fn test_nondet() {
         // from TraceForge takes a reference.
         let _n2 = numbers.nondet();
     });
+}
+
+#[test]
+fn test_named_nondet_without_predetermined() {
+    // Test that named_nondet works like regular nondet when no predetermined values are set
+    let stats = verify(Config::builder().build(), || {
+        let choice = named_nondet("test_choice");
+        // Should explore both true and false
+        if choice {
+            // one path
+        } else {
+            // another path
+        }
+    });
+    // Should explore 2 executions (true and false)
+    assert_eq!(stats.execs, 2);
+}
+
+#[test]
+fn test_named_nondet_with_predetermined_single_thread() {
+    // Test predetermined values in a single thread
+    let mut choices = HashMap::new();
+    choices.insert(
+        "my_choice".to_string(),
+        vec![
+            vec![true, false, true], // Thread 0 (main): occurrences 0, 1, 2
+        ],
+    );
+
+    let stats = verify(
+        Config::builder()
+            .with_predetermined_choices(choices)
+            .build(),
+        || {
+            let c1 = named_nondet("my_choice"); // Should be true
+            let c2 = named_nondet("my_choice"); // Should be false
+            let c3 = named_nondet("my_choice"); // Should be true
+
+            assert!(c1);
+            assert!(!c2);
+            assert!(c3);
+        },
+    );
+    // Should explore only 1 execution (predetermined path)
+    assert_eq!(stats.execs, 1);
+}
+
+#[test]
+fn test_named_nondet_with_predetermined_multiple_threads() {
+    // Test predetermined values across multiple threads
+    let mut choices = HashMap::new();
+    choices.insert(
+        "worker_choice".to_string(),
+        vec![
+            vec![true],  // First thread to call named_nondet
+            vec![false], // Second thread to call named_nondet
+        ],
+    );
+
+    let stats = verify(
+        Config::builder()
+            .with_predetermined_choices(choices)
+            .build(),
+        || {
+            let h1 = thread::spawn(|| {
+                let choice = named_nondet("worker_choice");
+                choice
+            });
+
+            let h2 = thread::spawn(|| {
+                let choice = named_nondet("worker_choice");
+                choice
+            });
+
+            let r1 = h1.join().unwrap();
+            let r2 = h2.join().unwrap();
+
+            // One thread should get true, the other false
+            // (order depends on which calls named_nondet first)
+            assert!(r1 != r2);
+        },
+    );
+    assert!(stats.execs >= 1);
+}
+
+#[test]
+fn test_named_nondet_mixed_predetermined_and_free() {
+    // Test that unspecified choices fall back to nondeterministic exploration
+    let mut choices = HashMap::new();
+    choices.insert(
+        "fixed_choice".to_string(),
+        vec![vec![true]], // Only thread 0, only occurrence 0
+    );
+
+    let stats = verify(
+        Config::builder()
+            .with_predetermined_choices(choices)
+            .build(),
+        || {
+            let fixed = named_nondet("fixed_choice"); // Predetermined: true
+            let free = named_nondet("free_choice"); // Not predetermined: should explore both
+
+            assert!(fixed); // Always true
+
+            if free {
+                // Explore this path
+            } else {
+                // And this path
+            }
+        },
+    );
+    // Should explore 2 executions (free choice explores both true and false)
+    assert_eq!(stats.execs, 2);
+}
+
+#[test]
+fn test_named_nondet_occurrence_tracking() {
+    // Test that occurrence counting works correctly (e.g., in a loop)
+    let mut choices = HashMap::new();
+    choices.insert(
+        "loop_choice".to_string(),
+        vec![vec![true, true, false]], // Three occurrences
+    );
+
+    let stats = verify(
+        Config::builder()
+            .with_predetermined_choices(choices)
+            .build(),
+        || {
+            let mut count = 0;
+            for _ in 0..3 {
+                if named_nondet("loop_choice") {
+                    count += 1;
+                }
+            }
+            // Should execute as: true, true, false → count = 2
+            assert_eq!(count, 2);
+        },
+    );
+    assert_eq!(stats.execs, 1);
+}
+
+#[test]
+fn test_named_nondet_two_threads_full_nondeterminism() {
+    // Test with two threads, each making choices in a loop, fully nondeterministic
+    // Messages are sent only when choice is true
+    use traceforge::channel;
+    use traceforge::SchedulePolicy;
+
+    for _ in 0..10 {
+        let stats = verify(
+            Config::builder()
+                .with_policy(SchedulePolicy::Arbitrary)
+                .build(),
+            || {
+                let (tx, rx) = channel::Builder::<String>::new().build();
+
+                // Worker function that both threads will execute
+                fn worker(tx: channel::Sender<String>, thread_name: &str) {
+                    for i in 0..2 {
+                        if named_nondet("worker_choice") {
+                            tx.send_msg(format!("{}_iter{}", thread_name, i));
+                        }
+                    }
+                }
+
+                // Spawn the worker threads
+                // Move tx into threads directly without keeping copy in main thread
+                let tx2 = tx.clone();
+
+                let h1 = thread::spawn(move || worker(tx, "thread1"));
+                let h2 = thread::spawn(move || worker(tx2, "thread2"));
+
+                h1.join().unwrap();
+                h2.join().unwrap();
+
+                // Receive all messages (max 4 possible)
+                for _ in 0..4 {
+                    rx.recv_msg_block();
+                }
+            },
+        );
+        // Each thread sends at most two messages and they are symmetric
+        // When both threads send two messages => 6 completed executions: 6 (receive order)
+        // When one thread sends no message and the other two => 2 blocked executions: 1 (receive order) x 2 (which thread sends no message)
+        // When one thread sends 1 message and the other 2 messages => 12 blocked executions: 3 (receive order) x 2 (which message is dropped) x 2 (which thread sends one message)
+        // When each thread sends 1 message => 8 blocked executions: 2 (receive order) x 2 (which message is dropped in one thread) x 2 (which message is dropped in the other thread)
+        // When one thread sends 1 message and the other none => 4 blocked executions: 1 (receive order) x 2 (which message is dropped in one thread) x 2 (which thread sends one message)
+        // When no thread sends a message => 1 blocked executions
+        assert_eq!(stats.execs, 6);
+        assert_eq!(stats.block, 27);
+    }
+}
+
+#[test]
+fn test_named_nondet_two_threads_one_predetermined() {
+    // Test with one thread predetermined and one thread free
+    use traceforge::channel;
+    use traceforge::SchedulePolicy;
+
+    // init_log();
+    let mut choices = HashMap::new();
+    choices.insert(
+        "worker_choice".to_string(),
+        vec![
+            vec![true, false], // Thread 0 (first to call): true then false
+                            // Thread 1 (second to call): not predetermined, will explore all options
+        ],
+    );
+
+    for _ in 0..10 {
+        let stats = verify(
+            Config::builder()
+                .with_policy(SchedulePolicy::Arbitrary)
+                .with_verbose(0)
+                .with_predetermined_choices(choices.clone())
+                .build(),
+            || {
+                let (tx, rx) = channel::Builder::<String>::new().build();
+
+                // Worker function that both threads will execute
+                fn worker(tx: channel::Sender<String>, thread_name: &str) {
+                    for i in 0..2 {
+                        if named_nondet("worker_choice") {
+                            tx.send_msg(format!("{}_iter{}", thread_name, i));
+                        }
+                    }
+                }
+
+                // Spawn the worker threads
+                // Move tx into threads directly without keeping copy in main thread
+                let tx2 = tx.clone();
+
+                let h1 = thread::spawn(move || worker(tx, "thread1"));
+                let h2 = thread::spawn(move || worker(tx2, "thread2"));
+
+                h1.join().unwrap();
+                h2.join().unwrap();
+
+                // Receive all messages (max 4 possible)
+                for i in 0..4 {
+                    rx.recv_msg_block();
+                    traceforge::assert(i < 3);
+                }
+            },
+        );
+
+        // One thread is predetermined
+        // When one thread sends 1 message and the other 2 messages => 3 blocked executions: 3 (receive order)
+        // When each thread sends 1 message => 4 blocked executions: 2 (receive order) x 2 (which message is dropped in one thread)
+        // When one thread sends 1 message and the other none => 1 blocked executions: 1 (receive order)
+        assert_eq!(stats.execs, 0);
+        assert_eq!(stats.block, 8);
+    }
+}
+
+#[test]
+fn test_named_nondet_two_threads_both_predetermined() {
+    // Test with both threads having predetermined values
+    use traceforge::channel;
+    use traceforge::SchedulePolicy;
+
+    let mut choices = HashMap::new();
+    choices.insert(
+        "worker_choice".to_string(),
+        vec![
+            vec![true, false], // Thread 0: send on iter 0, don't send on iter 1
+            vec![false, true], // Thread 1: don't send on iter 0, send on iter 1
+        ],
+    );
+
+    for _ in 0..10 {
+        let stats = verify(
+            Config::builder()
+                .with_policy(SchedulePolicy::Arbitrary)
+                .with_predetermined_choices(choices.clone())
+                .build(),
+            || {
+                let (tx, rx) = channel::Builder::<String>::new().build();
+
+                // Worker function that both threads will execute
+                fn worker(tx: channel::Sender<String>, thread_name: &str) {
+                    for i in 0..2 {
+                        if named_nondet("worker_choice") {
+                            tx.send_msg(format!("{}_iter{}", thread_name, i));
+                        }
+                    }
+                }
+
+                // Spawn the worker threads
+                // Move tx into threads directly without keeping copy in main thread
+                let tx2 = tx.clone();
+
+                let h1 = thread::spawn(move || worker(tx, "thread1"));
+                let h2 = thread::spawn(move || worker(tx2, "thread2"));
+
+                h1.join().unwrap();
+                h2.join().unwrap();
+
+                // Receive all messages (max 4 possible)
+                for i in 0..4 {
+                    rx.recv_msg_block();
+                    traceforge::assert(i < 2);
+                }
+            },
+        );
+
+        // Two threads are predetermined
+        // Each thread sends 1 message => 2 blocked executions: 2 (receive order)
+        assert_eq!(stats.execs, 0);
+        assert_eq!(stats.block, 2);
+    }
+}
+
+#[test]
+fn test_named_nondet_two_threads_both_predetermined_with_blocked_executions() {
+    // Test with both threads having predetermined values
+    use traceforge::channel;
+    use traceforge::SchedulePolicy;
+
+    // init_log();
+    let mut choices = HashMap::new();
+    choices.insert(
+        "worker_choice".to_string(),
+        vec![
+            vec![true, false], // Thread 0: send on iter 0, don't send on iter 1
+            vec![false, true], // Thread 1: don't send on iter 0, send on iter 1
+        ],
+    );
+
+    for _ in 0..100 {
+        let stats = verify(
+            Config::builder()
+                .with_policy(SchedulePolicy::Arbitrary)
+                .with_predetermined_choices(choices.clone())
+                .build(),
+            || {
+                let (tx, rx) = channel::Builder::<String>::new().build();
+
+                // Worker function that both threads will execute
+                fn worker(tx: channel::Sender<String>, thread_name: &str) {
+                    assume!(<bool>::nondet());
+                    for i in 0..2 {
+                        if named_nondet("worker_choice") {
+                            tx.send_msg(format!("{}_iter{}", thread_name, i));
+                        }
+                    }
+                }
+
+                // Spawn the worker threads
+                // Move tx into threads directly without keeping copy in main thread
+                let tx2 = tx.clone();
+
+                let h1 = thread::spawn(move || worker(tx, "thread1"));
+                let h2 = thread::spawn(move || worker(tx2, "thread2"));
+
+                h1.join().unwrap();
+                h2.join().unwrap();
+
+                // Receive all messages (max 4 possible)
+                for i in 0..4 {
+                    rx.recv_msg_block();
+                    traceforge::assert(i < 2);
+                }
+            },
+        );
+
+        // Two threads are predetermined, once they pass their non-determinstic assume
+        // Each thread sends 1 message => 2 blocked executions: 2 (receive order)
+        // Only one thread is unblocked => 2 blocked executions: 2 (which thread is unblocked)
+        // Both threads are blocked
+        assert_eq!(stats.execs, 0);
+        assert_eq!(stats.block, 5);
+    }
+}
+
+#[test]
+fn test_named_nondet_two_threads_mixed_names() {
+    // Test with two threads using different named choices
+    use traceforge::channel;
+    use traceforge::SchedulePolicy;
+
+    //init_log();
+    let mut choices = HashMap::new();
+    // Provide predetermined values
+    choices.insert(
+        "choice_a".to_string(),
+        vec![
+            vec![true, true], // always send
+        ],
+    );
+    choices.insert(
+        "choice_b".to_string(),
+        vec![
+            vec![false, false], // never send
+        ],
+    );
+
+    for _ in 0..10 {
+        let stats = verify(
+            Config::builder()
+                .with_policy(SchedulePolicy::Arbitrary)
+                .with_verbose(0)
+                .with_predetermined_choices(choices.clone())
+                .build(),
+            || {
+                let (tx, rx) = channel::Builder::<String>::new().build();
+
+                // Spawn the worker threads
+                // Move tx into threads directly without keeping copy in main thread
+                let tx2 = tx.clone();
+
+                let h1 = thread::spawn(move || {
+                    for i in 0..2 {
+                        if named_nondet("choice_a") {
+                            tx.send_msg(format!("thread1_iter{}", i));
+                        }
+                    }
+                });
+
+                let h2 = thread::spawn(move || {
+                    for i in 0..2 {
+                        if named_nondet("choice_b") {
+                            tx2.send_msg(format!("thread2_iter{}", i));
+                        }
+                    }
+                });
+
+                h1.join().unwrap();
+                h2.join().unwrap();
+
+                // Collect exactly 2 messages (choice_a always true: thread1 sends iter0 and iter1)
+                let msg1 = rx.recv_msg_block();
+                let msg2 = rx.recv_msg_block();
+                let messages = vec![msg1, msg2];
+
+                // Thread 1 sends 2 messages (choice_a is always true)
+                // Thread 2 sends 0 messages (choice_b is always false)
+                assert_eq!(messages.len(), 2);
+
+                assert!(
+                    messages.iter().all(|m| m.contains("thread1")),
+                    "All messages should be from thread1: {:?}",
+                    messages
+                );
+            },
+        );
+
+        // Both threads are predetermined, exploring only one interleaving
+        assert!(stats.execs == 1);
+    }
 }


### PR DESCRIPTION
*Description of changes:*

This addresses two issues:
1. Disabling the tracking of coverage information in the default case. The tracking can now be enabled via the configuration flag keep_per_execution_coverage.
2. Adding a new API called named_nondet which makes it possible to give names to nondeterministic choices and fix their values in the configuration object.