### PR TITLE
Fixing drops in async deadlocks

### DIFF
--- a/traceforge/Cargo.toml
+++ b/traceforge/Cargo.toml
@@ -32,7 +32,7 @@ dyn-eq = "0.1.3"
 merging-iterator = "1.3.0"
 bytes = "1.10"
 indexmap = "2.12"
-tokio = "*"
+tokio ={ version = "*", features = ["full"] }
 
 [dev-dependencies] 
 serial_test = "*"

--- a/traceforge/src/future/mod.rs
+++ b/traceforge/src/future/mod.rs
@@ -376,28 +376,9 @@ impl<T> JoinHandle<T> {
     pub fn thread(&self) -> &Thread {
         &self.thread
     }
-}
 
-// TODO: need to work out all the error cases here
-/// Task failed to execute to completion.
-#[derive(Debug)]
-pub enum JoinError {
-    /// Task was aborted
-    Cancelled,
-}
-
-impl Display for JoinError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            JoinError::Cancelled => write!(f, "task was cancelled"),
-        }
-    }
-}
-
-impl Error for JoinError {}
-
-impl<T> Drop for JoinHandle<T> {
-    fn drop(&mut self) {
+    // Useful for the Drop implementation
+    pub fn abort(&self) {
         // If a Join Handle for a spawned task is never awaited, one could abort the task by calling `self.abort()`
         // But this may mean that certain side effects (message sends or receives) of the task
         // do not get to run.
@@ -424,6 +405,37 @@ impl<T> Drop for JoinHandle<T> {
             let ack = self.com.receiver.recv_msg_block();
             assert!(matches!(ack, PollerMsg::Done));
         }
+    }
+}
+
+// TODO: need to work out all the error cases here
+/// Task failed to execute to completion.
+#[derive(Debug)]
+pub enum JoinError {
+    /// Task was aborted
+    Cancelled,
+}
+
+impl Display for JoinError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JoinError::Cancelled => write!(f, "task was cancelled"),
+        }
+    }
+}
+
+impl Error for JoinError {}
+
+impl<T> Drop for JoinHandle<T> {
+    fn drop(&mut self) {
+        // Skip during panic unwinding. raw_cancel() triggers a Cancel-panic
+        // inside generators to unwind their stacks; calling Must API
+        // (send_msg, recv_msg_block) during that unwinding would cause a
+        // nested panic and abort.
+        if std::thread::panicking() {
+            return;
+        }
+        self.abort();
     }
 }
 

--- a/traceforge/src/runtime/execution.rs
+++ b/traceforge/src/runtime/execution.rs
@@ -56,11 +56,26 @@ impl Execution {
                 Some(format!("main-thread-{:?}", std::thread::current().id())),
             );
 
-            // Run the test to completion
-            while self.step() {}
-
-            // Cleanup the state before it goes out of `EXECUTION_STATE` scope
+            // Run the test 
+            let panic_payload = match panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                while self.step() {}
+            })) {
+                Ok(()) => None,
+                Err(e) => {
+                    // Deadlock or other failure panicked out of step().
+                    // Set state to Stopped so cleanup() can proceed.
+                    ExecutionState::with(|state| {
+                        state.current_task = ScheduledTask::Stopped;
+                    });
+                    Some(e)
+                }
+            };
+            
             ExecutionState::cleanup();
+
+            if let Some(payload) = panic_payload {
+                panic::resume_unwind(payload);
+            }
         });
     }
 
@@ -262,13 +277,7 @@ impl ExecutionState {
         })
     }
 
-    /// Prepare this ExecutionState to be dropped. Call this before dropping so that the tasks have
-    /// a chance to run their drop handlers while `EXECUTION_STATE` is still in scope.
     fn cleanup() {
-        // A slightly delicate dance here: we need to drop the tasks from outside of `Self::with`,
-        // because a task's Drop impl might want to call back into `ExecutionState` (to check
-        // `should_stop()`). So we pull the tasks out of the `ExecutionState`, leaving it in an
-        // invalid state, but no one should still be accessing the tasks anyway.
         let (mut tasks, final_state) = Self::with(|state| {
             assert!(
                 state.current_task == ScheduledTask::Stopped
@@ -280,14 +289,24 @@ impl ExecutionState {
             )
         });
 
-        for task in tasks.drain(..) {
-            assert!(
-                final_state == ScheduledTask::Stopped || task.finished(),
+        for task in tasks.drain(..) {                                                                                                                                                                                   
+            let finished = task.finished();
+            assert!(                                                                                                                                                                                                    
+                final_state == ScheduledTask::Stopped || finished,                                                                                                                                                    
                 "execution finished but task is not"
             );
-            Rc::try_unwrap(task.continuation)
-                .map_err(|_| ())
-                .expect("couldn't cleanup a future");
+            match Rc::try_unwrap(task.continuation) {
+                Ok(refcell) => {
+                    if !finished {
+                        let mut pc = refcell.borrow_mut();
+                        pc.cancel_gen();
+                        pc.reinitialize_generator();
+                        drop(pc);
+                    }
+                    drop(refcell);
+                }
+                Err(_) => panic!("couldn't cleanup a future"),
+            }
         }
 
         // while Self::with(|state| state.storage.pop()).is_some() {}

--- a/traceforge/src/runtime/failure.rs
+++ b/traceforge/src/runtime/failure.rs
@@ -70,6 +70,7 @@ pub struct PanicHookGuard;
 
 impl Drop for PanicHookGuard {
     fn drop(&mut self) {
+        if std::thread::panicking() { return; }
         PANIC_HOOK.with(|lock| *lock.lock().unwrap() = PanicHookState::Disarmed);
     }
 }

--- a/traceforge/src/runtime/thread/continuation.rs
+++ b/traceforge/src/runtime/thread/continuation.rs
@@ -8,6 +8,7 @@ use crate::runtime::execution::ExecutionState;
 use generator::{Generator, Gn};
 use scoped_tls::scoped_thread_local;
 use std::cell::{Cell, RefCell};
+use std::mem::ManuallyDrop;
 use std::collections::VecDeque;
 use std::ops::Deref;
 use std::ops::DerefMut;
@@ -24,7 +25,7 @@ scoped_thread_local! {
 /// to run via `initialize`. A continuation is only reusable if the previous function it was
 /// executing completed.
 pub(crate) struct Continuation {
-    generator: Generator<'static, ContinuationInput, ContinuationOutput>,
+    generator: ManuallyDrop<Generator<'static, ContinuationInput, ContinuationOutput>>,
     function: ContinuationFunction,
     state: ContinuationState,
 }
@@ -96,11 +97,40 @@ impl Continuation {
         debug_assert_eq!(ret, ContinuationOutput::Finished);
 
         Self {
-            generator: gen,
+            generator: ManuallyDrop::new(gen), 
             function,
             state: ContinuationState::NotReady,
         }
     }
+
+    /// Reinitialize a cancelled/stuck continuation so it can be reused.
+    /// This reuses the existing mmap'd stack (no new allocation).
+    pub fn reinitialize_generator(&mut self) {
+        // Clear any unconsumed function left in the cell
+        self.function.0.take();
+
+        let function = self.function.clone();
+        self.generator.init_code(move || {
+            let _ = &function;
+            loop {
+                match generator::yield_(ContinuationOutput::Finished) {
+                    None | Some(ContinuationInput::Exit) => break,
+                    _ => (),
+                }
+                let f = function.0.take().expect("must have a function to run");
+                f();
+            }
+            ContinuationOutput::Exited
+        });
+        let ret = self.generator.resume().unwrap();
+        debug_assert_eq!(ret, ContinuationOutput::Finished);
+        self.state = ContinuationState::NotReady;
+    }
+
+    pub fn cancel_gen(&mut self) {
+        self.generator.cancel();
+    }
+	 
 
     /// Provide a new function for the continuation to execute. The continuation must
     /// be in reusable state.
@@ -158,10 +188,12 @@ impl Drop for Continuation {
         // arbitrary user code. Its resources will still be cleaned up when the underlying
         // generator is dropped, but doing so is slower (the generator impl invokes a panic
         // inside the continuation), so this drop handler exists to avoid it when possible.
-        if self.reusable() {
+        let reusable = self.reusable();
+        if reusable {
             let ret = self.resume_with_input(ContinuationInput::Exit);
             debug_assert_eq!(ret, ContinuationOutput::Exited);
         }
+        // implicit: self.generator drops here → StackBox::drop → munmap?
     }
 }
 
@@ -232,7 +264,8 @@ pub(crate) struct PooledContinuation {
 impl Drop for PooledContinuation {
     fn drop(&mut self) {
         let c = self.continuation.take().unwrap();
-        if c.reusable() {
+        let reusable = c.reusable();
+        if reusable {
             self.queue.borrow_mut().push_back(c);
         }
     }
@@ -263,6 +296,13 @@ unsafe impl Send for PooledContinuation {}
 
 /// Possibly yield back to the executor to perform a context switch.
 pub(crate) fn switch() {
+    // During panic unwinding (including the Cancel-panic triggered by
+    // raw_cancel() to clean up non-reusable generators), do not attempt
+    // a context switch. Yielding during Cancel-unwind would interrupt
+    // the unwind and leave the generator in an inconsistent state.
+    if std::thread::panicking() {
+        return;
+    }
     if ExecutionState::maybe_yield() {
         let r = generator::yield_(ContinuationOutput::Yielded).unwrap();
         assert!(matches!(r, ContinuationInput::Resume));

--- a/traceforge/src/sync/mpsc.rs
+++ b/traceforge/src/sync/mpsc.rs
@@ -73,6 +73,84 @@ impl<T: Message + Clone + 'static> Receiver<T> {
     }
 }
 
+pub fn unbounded_channel<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>)
+where
+    T: Clone + std::fmt::Debug + PartialEq + Message + 'static,
+{
+    let (tx, rx) = crate::channel::Builder::<T>::new().build();
+    (UnboundedSender::new(tx), UnboundedReceiver::new(rx))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct UnboundedSender<T> {
+    sender: crate::channel::Sender<T>,
+}
+
+unsafe impl<T: Send> Send for UnboundedSender<T> {}
+
+unsafe impl<T: Sync> Sync for UnboundedSender<T> {}
+
+impl<T: Message + 'static> UnboundedSender<T> {
+    fn new(sender: crate::channel::Sender<T>) -> Self {
+        UnboundedSender { sender }
+    }
+    pub fn send(&self, v: T) -> Result<(), error::SendError<T>> {
+        self.sender.send_msg(v);
+        Ok(())
+    }
+
+    pub fn try_send(&self, v: T) -> Result<(), error::TrySendError<T>> {
+        self.sender.send_msg(v);
+        Ok(())
+    }
+
+    pub fn is_closed(&self) -> bool {
+        nondet()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct UnboundedReceiver<T> {
+    receiver: crate::channel::Receiver<T>,
+}
+unsafe impl<T: Send> Send for UnboundedReceiver<T> {}
+
+unsafe impl<T: Sync> Sync for UnboundedReceiver<T> {}
+
+impl<T: Message + Clone + 'static> UnboundedReceiver<T> {
+    fn new(receiver: crate::channel::Receiver<T>) -> Self {
+        UnboundedReceiver { receiver }
+    }
+
+    // This is incomplete as it does not model receive errors.
+    // A complete implementation would non-deterministically return None.
+    pub async fn recv(&self) -> Option<T> {
+        info!("This is an incomplete implementation. It never returns None");
+        Some(self.receiver.async_recv_msg().await)
+    }
+
+    // This is incomplete as it does not model receive errors.
+    // A complete implementation would non-deterministically return an error.
+    pub fn try_recv(&self) -> Result<T, error::TryRecvError> {
+        info!("This is an incomplete implementation. It never returns errors");
+        Ok(self.receiver.recv_msg_block())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        nondet()
+    }
+
+    pub fn len(&self) -> usize {
+        nondet() as usize
+    }
+
+    pub fn close(&mut self) {}
+
+    pub fn is_closed(&self) -> bool {
+        nondet()
+    }
+}
+
 pub mod error {
     //! Channel error types.
 

--- a/traceforge/src/sync/mutex.rs
+++ b/traceforge/src/sync/mutex.rs
@@ -294,6 +294,7 @@ impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
 
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     fn drop(&mut self) {
+        if std::thread::panicking() { return; }
         send_tagged_msg(
             self.mutex.synchronizer,
             UNLOCK_TAG,
@@ -310,6 +311,7 @@ impl<T: ?Sized + Debug> Debug for MutexGuard<'_, T> {
 
 impl<T: ?Sized> Drop for OwnedMutexGuard<T> {
     fn drop(&mut self) {
+        if std::thread::panicking() { return; }
         send_tagged_msg(
             self.mutex.synchronizer,
             UNLOCK_TAG,

--- a/traceforge/src/sync/rwlock.rs
+++ b/traceforge/src/sync/rwlock.rs
@@ -227,6 +227,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLockWriteGuard<'_, T> {
 
 impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
     fn drop(&mut self) {
+        if std::thread::panicking() { return; }
         let tid = self.lock.backing_tid;
         crate::send_tagged_msg(
             tid,
@@ -239,6 +240,7 @@ impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
 
 impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
     fn drop(&mut self) {
+        if std::thread::panicking() { return; }
         let tid = self.lock.backing_tid;
         crate::send_tagged_msg(
             tid,
@@ -316,6 +318,7 @@ where
 
 impl<T: ?Sized, U: ?Sized> Drop for OwnedRwLockReadGuard<T, U> {
     fn drop(&mut self) {
+        if std::thread::panicking() { return; }
         let tid = self.lock.backing_tid;
         crate::send_tagged_msg(
             tid,
@@ -353,6 +356,7 @@ where
 
 impl<T: ?Sized, U: ?Sized> Drop for OwnedRwLockWriteGuard<T, U> {
     fn drop(&mut self) {
+        if std::thread::panicking() { return; }
         let tid = self.lock.backing_tid;
         crate::send_tagged_msg(
             tid,

--- a/traceforge/tests/async_test.rs
+++ b/traceforge/tests/async_test.rs
@@ -11,6 +11,7 @@ use traceforge::{cover, future, nondet, recv_msg_block, send_msg, thread, Config
 use futures::future::{join_all, pending, select, select_all, Either};
 use futures::prelude::*;
 use futures::stream::FuturesUnordered;
+use traceforge::TypeNondet;
 
 const TEST_RUNS: i32 = 20;
 
@@ -911,4 +912,92 @@ fn no_await() {
     // the async_recv is dropped, it receives the cancellation message and
     // terminates successfully.
     assert_eq!(stats.execs, 1);
+}
+
+pub use tokio::time::{Duration, Instant};
+
+pub struct Interval {
+    period: Duration,
+    ticks_remaining: usize,
+}
+
+impl Interval {
+    pub async fn tick(&mut self) {
+        if self.ticks_remaining > 0 {
+            self.ticks_remaining -= 1;
+
+            std::future::poll_fn(|_cx| {
+                if <bool>::nondet() {
+                    std::task::Poll::Ready(())
+                } else {
+                    std::task::Poll::Pending
+                }
+            })
+            .await
+        } else {
+            // No more ticks, return only Pending
+            std::future::poll_fn(|_cx| {
+                std::task::Poll::Pending
+            })
+            .await
+        }
+    }
+
+    pub fn reset(&mut self) {}
+
+    pub fn reset_immediately(&mut self) {}
+
+    pub fn period(&self) -> Duration {
+        self.period
+    }
+}
+
+pub fn interval(period: Duration) -> Interval {
+    Interval {
+        period,
+        ticks_remaining: 1,
+    }
+}
+
+pub fn interval_at(_start: tokio::time::Instant, period: Duration) -> Interval {
+    interval(period)
+}
+
+#[test]
+fn cancel_recv_macro_select() {
+    for _ in 0..10 {
+        let stats = traceforge::verify(
+            Config::builder()
+                .with_verbose(0)
+                .with_policy(SchedulePolicy::Arbitrary)
+                .build(),
+            || {
+                future::block_on(async {
+                    let (sender1, receiver1) = traceforge::sync::mpsc::unbounded_channel::<u32>();
+
+                    let mut wait_interval: Interval = interval_at(Instant::now(), Duration::from_millis(500));
+
+                    thread::spawn(move || {
+                        let _ = sender1.send(1);
+                    });
+
+                    loop {
+                        tokio::select! { 
+                            biased;   
+                            _ = wait_interval.tick() => {
+                                traceforge::send_msg(traceforge::thread::construct_thread_id(0),format!("timer ticked").to_string());
+                                0u32
+                            },                                                                                                                                                               
+                            val = receiver1.recv() => {
+                                traceforge::send_msg(traceforge::thread::construct_thread_id(0),format!("val received").to_string());
+                                val.expect("this should have something")
+                            },                                                                                                                                                              
+                        };
+                    }
+                });
+            },
+        );
+        assert_eq!(stats.execs, 0);
+        assert_eq!(stats.block, 6);
+    }
 }


### PR DESCRIPTION
*Description of changes:*

This fixes an issue related to the exploration of code that contains loops where each iteration is a select!. Enforcing that such loops are bounded (stop in a deadlock) made the exploration end with a panic "generator is done while drop". Note that the fix may require that mutexes are dropped explicitly since the Drop implementation may do nothing when catching panics.