### PR TITLE
Add support for vector tags

### DIFF
--- a/traceforge/src/channel.rs
+++ b/traceforge/src/channel.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, iter, sync::Arc};
+use std::{future::Future, iter};
 
 use serde::{Deserialize, Serialize};
 
@@ -7,14 +7,15 @@ use crate::{
     identifier::Identifier,
     loc::{CommunicationModel, Loc},
     msg::Message,
-    predicate::PredicateType,
     runtime::execution::ExecutionState,
     thread::ThreadId,
     ConsType, Unique,
 };
 
-// added for try_recv
+use crate::predicate::{normalize_vec_tag, PredicateType};
 use std::fmt::Error;
+use std::sync::Arc;
+
 type Result<T> = std::result::Result<T, Error>;
 
 #[allow(deprecated)]
@@ -104,6 +105,16 @@ impl<T: Message + 'static> Sender<T> {
         crate::send_msg_with_tag(v, Some(tag), &self.inner, self.comm, true)
     }
 
+    pub fn send_vec_tagged_msg(&self, tag: Vec<u32>, v: T) {
+        let tag = if tag.is_empty() { None } else { Some(tag) };
+        crate::send_msg_with_vec_tag(v, tag, &self.inner, self.comm, false)
+    }
+
+    pub fn send_vec_tagged_lossy_msg(&self, tag: Vec<u32>, v: T) {
+        let tag = if tag.is_empty() { None } else { Some(tag) };
+        crate::send_msg_with_vec_tag(v, tag, &self.inner, self.comm, true)
+    }
+
     pub fn send_msg(&self, v: T) {
         crate::send_msg_with_tag(v, None, &self.inner, self.comm, false);
     }
@@ -147,7 +158,17 @@ impl<T: Message + Clone + 'static> Receiver<T> {
     where
         F: Fn(Option<u32>) -> bool + 'static + Send + Sync,
     {
-        let f = move |_tid, opt| f(opt);
+        self.recv_vec_tagged_msg(move |tag_vec| {
+            let tag = tag_vec.as_ref().and_then(|tags| tags.first().copied());
+            f(tag)
+        })
+    }
+
+    pub fn recv_vec_tagged_msg<F>(&self, f: F) -> Option<T>
+    where
+        F: Fn(Option<Vec<u32>>) -> bool + 'static + Send + Sync,
+    {
+        let f = move |_tid, opt| f(normalize_vec_tag(opt));
         crate::recv_msg_with_tag(
             iter::once(&self.inner),
             self.comm,
@@ -168,7 +189,17 @@ impl<T: Message + Clone + 'static> Receiver<T> {
     where
         F: Fn(Option<u32>) -> bool + 'static + Send + Sync,
     {
-        let f = move |_tid, opt| f(opt);
+        self.recv_vec_tagged_msg_block(move |tag_vec| {
+            let tag = tag_vec.as_ref().and_then(|tags| tags.first().copied());
+            f(tag)
+        })
+    }
+
+    pub fn recv_vec_tagged_msg_block<F>(&self, f: F) -> T
+    where
+        F: Fn(Option<Vec<u32>>) -> bool + 'static + Send + Sync,
+    {
+        let f = move |_tid, opt| f(normalize_vec_tag(opt));
         crate::recv_msg_block_with_tag(
             iter::once(&self.inner),
             self.comm,

--- a/traceforge/src/lib.rs
+++ b/traceforge/src/lib.rs
@@ -30,7 +30,8 @@ pub use testmode::{parallel_test, test};
 pub mod thread;
 mod vector_clock;
 
-pub use crate::msg::Val; // `Val` is used by monitors.
+pub use crate::msg::Val;
+// `Val` is used by monitors.
 
 use channel::{cons_to_model, self_loc_comm, thread_loc_comm, Receiver};
 use coverage::ExecutionObserver;
@@ -45,7 +46,7 @@ use runtime::failure::persist_task_failure;
 use runtime::thread::continuation::{ContinuationPool, CONTINUATION_POOL};
 use runtime::thread::switch;
 
-use log::{info, trace, debug};
+use log::{debug, info, trace};
 use serde::{Deserialize, Serialize};
 use smallvec::alloc::sync::Arc;
 use std::cell::RefCell;
@@ -59,7 +60,7 @@ use thread::{spawn_without_switch, JoinHandle, ThreadId};
 use crate::event_label::*;
 use crate::exec_pool::ExecutionPool;
 use crate::must::{MonitorInfo, Must};
-use crate::predicate::PredicateType;
+use crate::predicate::{normalize_vec_tag, PredicateType};
 
 use std::any::type_name;
 
@@ -204,7 +205,7 @@ pub struct Config {
     pub(crate) parallel: bool,
     pub(crate) parallel_workers: Option<usize>,
     pub(crate) keep_per_execution_coverage: bool,
-    pub(crate) predetermined_choices: HashMap<String, Vec<Vec<bool>>>,    
+    pub(crate) predetermined_choices: HashMap<String, Vec<Vec<bool>>>,
     #[serde(skip)]
     pub(crate) callbacks: Arc<Mutex<Vec<Box<dyn ExecutionObserver + Send>>>>,
 }
@@ -266,7 +267,7 @@ impl ConfigBuilder {
             parallel: false,
             parallel_workers: None,
             keep_per_execution_coverage: false,
-	        predetermined_choices: HashMap::new(),
+            predetermined_choices: HashMap::new(),
             callbacks: Arc::new(Mutex::new(Vec::new())),
         })
     }
@@ -487,7 +488,6 @@ impl ConfigBuilder {
         self.0.predetermined_choices = choices;
         self
     }
-	 
 
     /// Consumes the builder and produces the [`Config`]
     pub fn build(self) -> Config {
@@ -772,8 +772,25 @@ where
     F: Fn(ThreadId, Option<u32>) -> bool + 'static + Send + Sync,
     T: Message + 'static,
 {
+    select_vec_tagged_msg(recvs, comm, move |tid, tag| {
+        let tag = tag.and_then(|tags| tags.first().copied());
+        f(tid, tag)
+    })
+}
+
+pub fn select_vec_tagged_msg<'a, F, T>(
+    recvs: impl Iterator<Item = &'a &'a Receiver<T>>,
+    comm: CommunicationModel,
+    f: F,
+) -> Option<(T, usize)>
+where
+    F: Fn(ThreadId, Option<Vec<u32>>) -> bool + 'static + Send + Sync,
+    T: Message + 'static,
+{
     let locs = recvs.map(|r| &r.inner);
-    recv_msg_with_tag(locs, comm, Some(PredicateType(Arc::new(f))))
+    recv_msg_with_tag(locs, comm, Some(PredicateType(Arc::new(move |tid, tag| {
+        f(tid, normalize_vec_tag(tag))
+    }))))
 }
 
 pub fn select_msg_block<'a, T: Message + 'static>(
@@ -793,8 +810,25 @@ where
     F: Fn(ThreadId, Option<u32>) -> bool + 'static + Send + Sync,
     T: Message + 'static,
 {
+    select_vec_tagged_msg_block(recvs, comm, move |tid, tag| {
+        let tag = tag.and_then(|tags| tags.first().copied());
+        f(tid, tag)
+    })
+}
+
+pub fn select_vec_tagged_msg_block<'a, F, T>(
+    recvs: impl Iterator<Item = &'a &'a Receiver<T>>,
+    comm: CommunicationModel,
+    f: F,
+) -> (T, usize)
+where
+    F: Fn(ThreadId, Option<Vec<u32>>) -> bool + 'static + Send + Sync,
+    T: Message + 'static,
+{
     let locs = recvs.map(|r| &r.inner);
-    recv_msg_block_with_tag(locs, comm, Some(PredicateType(Arc::new(f))))
+    recv_msg_block_with_tag(locs, comm, Some(PredicateType(Arc::new(move |tid, tag| {
+        f(tid, normalize_vec_tag(tag))
+    }))))
 }
 
 // Main API
@@ -823,6 +857,18 @@ pub fn send_tagged_lossy_msg<T: Message + 'static>(t: ThreadId, tag: u32, v: T) 
     send_msg_with_tag(v, Some(tag), &loc, comm, true)
 }
 
+/// Sends to `t` the message `v` tagged with a vector 'tag
+pub fn send_vec_tagged_msg<T: Message + 'static>(t: ThreadId, tag: Vec<u32>, v: T) {
+    let (loc, comm) = thread_loc_comm(t);
+    send_msg_with_vec_tag(v, Some(tag), &loc, comm, false)
+}
+
+/// Sends to `t` the message `v`, which can be lost, tagged with 'tag
+pub fn send_vec_tagged_lossy_msg<T: Message + 'static>(t: ThreadId, tag: Vec<u32>, v: T) {
+    let (loc, comm) = thread_loc_comm(t);
+    send_msg_with_vec_tag(v, Some(tag), &loc, comm, true)
+}
+
 /// Helper for [`send_msg`] and [`send_tagged_msg`]
 fn send_msg_with_tag<T: Message + 'static>(
     v: T,
@@ -831,6 +877,18 @@ fn send_msg_with_tag<T: Message + 'static>(
     comm: CommunicationModel,
     lossy: bool,
 ) {
+    send_msg_with_vec_tag(v, tag.map(|t| vec![t]), loc, comm, lossy);
+}
+
+/// Helper for vector tagged message sending
+fn send_msg_with_vec_tag<T: Message + 'static>(
+    v: T,
+    tag: Option<Vec<u32>>,
+    loc: &Loc,
+    comm: CommunicationModel,
+    lossy: bool,
+) {
+    let tag = normalize_vec_tag(tag);
     switch();
     ExecutionState::with(|s| {
         // creating the send label for the system send
@@ -899,8 +957,27 @@ where
     F: Fn(ThreadId, Option<u32>) -> bool + 'static + Send + Sync,
     T: Message + 'static,
 {
+    recv_vec_tagged_msg(move |tid, tag| {
+        let tag = tag.and_then(|tags| tags.first().copied());
+        f(tid, tag)
+    })
+}
+
+/// Returns a vector-tagged message from the thread queue or times out
+pub fn recv_vec_tagged_msg<F, T>(f: F) -> Option<T>
+where
+    F: Fn(ThreadId, Option<Vec<u32>>) -> bool + 'static + Send + Sync,
+    T: Message + 'static,
+{
     let (loc, comm) = self_loc_comm();
-    recv_msg_with_tag(iter::once(&loc), comm, Some(PredicateType(Arc::new(f)))).map(|x| x.0)
+    recv_msg_with_tag(
+        iter::once(&loc),
+        comm,
+        Some(PredicateType(Arc::new(move |tid, tag| {
+            f(tid, normalize_vec_tag(tag))
+        }))),
+    )
+    .map(|x| x.0)
 }
 
 fn recv_msg_with_tag<'a, T: Message + 'static>(
@@ -954,8 +1031,27 @@ where
     F: Fn(ThreadId, Option<u32>) -> bool + 'static + Send + Sync,
     T: Message + 'static,
 {
+    recv_vec_tagged_msg_block(move |tid, tag| {
+        let tag = tag.and_then(|tags| tags.first().copied());
+        f(tid, tag)
+    })
+}
+
+/// Returns a message from the queue that matches a vector `tag`
+pub fn recv_vec_tagged_msg_block<F, T>(f: F) -> T
+where
+    F: Fn(ThreadId, Option<Vec<u32>>) -> bool + 'static + Send + Sync,
+    T: Message + 'static,
+{
     let (loc, comm) = self_loc_comm();
-    recv_msg_block_with_tag(iter::once(&loc), comm, Some(PredicateType(Arc::new(f)))).0
+    recv_msg_block_with_tag(
+        iter::once(&loc),
+        comm,
+        Some(PredicateType(Arc::new(move |tid, tag| {
+            f(tid, normalize_vec_tag(tag))
+        }))),
+    )
+    .0
 }
 
 /// Helper function for [`recv_msg_block`] and [`recv_tagged_msg_block`]
@@ -1156,7 +1252,6 @@ pub fn named_nondet(name: &str) -> bool {
         s.must.borrow_mut().handle_ctoss(CToss::new(pos, toss))
     })
 }
-	 
 
 use crate::monitor_types::{Monitor, MonitorResult};
 use std::ops::{Range, RangeInclusive};

--- a/traceforge/src/loc.rs
+++ b/traceforge/src/loc.rs
@@ -65,7 +65,7 @@ impl RecvLoc {
     /// Returns whether the receive's tag matches the send's tag
     pub(crate) fn matches_tag(&self, send: &SendMsg) -> bool {
         let send_loc = send.send_loc();
-        self.tag.is_none() || self.tag.as_ref().unwrap().0(send_loc.sender_tid, send_loc.tag)
+        self.tag.is_none() || self.tag.as_ref().unwrap().0(send_loc.sender_tid, send_loc.tag.clone())
     }
 
     /// Return whether the receive's tag and any of it's locations matches the send
@@ -87,7 +87,7 @@ pub(crate) struct SendLoc {
     #[serde(skip)]
     loc: Option<Loc>,
     pub(crate) sender_tid: ThreadId,
-    pub(crate) tag: Option<u32>,
+    pub(crate) tag: Option<Vec<u32>>,
 }
 
 impl SendLoc {
@@ -101,7 +101,7 @@ impl SendLoc {
         }
     }
 
-    pub(crate) fn new(loc: &Loc, sender_tid: ThreadId, tag: Option<u32>) -> Self {
+    pub(crate) fn new(loc: &Loc, sender_tid: ThreadId, tag: Option<Vec<u32>>) -> Self {
         SendLoc {
             loc: Some(loc.clone()),
             sender_tid,

--- a/traceforge/src/predicate.rs
+++ b/traceforge/src/predicate.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 /// A separate type helps in serialization as it isolates all
 /// the code relevant to serializing/deserializing tag predicates.
 #[derive(Clone)]
-pub(crate) struct PredicateType(pub Arc<dyn Send + Sync + Fn(ThreadId, Option<u32>) -> bool>);
+pub(crate) struct PredicateType(pub Arc<dyn Send + Sync + Fn(ThreadId, Option<Vec<u32>>) -> bool>);
 
 impl Serialize for PredicateType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -54,5 +54,12 @@ impl<'de> Deserialize<'de> for PredicateType {
             Ok(_u) => Ok(PredicateType(Arc::new(|_, _| true))),
             Err(e) => Err(e),
         }
+    }
+}
+
+pub(crate) fn normalize_vec_tag(tag: Option<Vec<u32>>) -> Option<Vec<u32>> {
+    match tag {
+        Some(tag) if tag.is_empty() => None,
+        other => other,
     }
 }

--- a/traceforge/tests/vec_tags.rs
+++ b/traceforge/tests/vec_tags.rs
@@ -1,0 +1,73 @@
+extern crate traceforge;
+
+use traceforge::thread;
+use traceforge::*;
+use SchedulePolicy::*;
+
+#[derive(Clone, PartialEq, Debug)]
+enum Msg {
+    Val(i32),
+}
+
+#[test]
+fn vec_tag_basic_and_empty_is_none() {
+    let stats = traceforge::verify(
+        Config::builder()
+            .with_policy(LTR)
+            .with_cons_type(ConsType::FIFO)
+            .build(),
+        || {
+            let receiver = thread::spawn(move || {
+                let v_exact = match traceforge::recv_vec_tagged_msg_block(move |_, tag| {
+                    tag == Some(vec![7, 1])
+                }) {
+                    Msg::Val(v) => v,
+                };
+                assert_eq!(v_exact, 71);
+
+                let v_none = match traceforge::recv_vec_tagged_msg_block(move |_, tag| tag.is_none())
+                {
+                    Msg::Val(v) => v,
+                };
+                assert_eq!(v_none, 0);
+            });
+
+            traceforge::send_vec_tagged_msg(receiver.thread().id(), vec![], Msg::Val(0));
+            traceforge::send_vec_tagged_msg(receiver.thread().id(), vec![7, 1], Msg::Val(71));
+
+            let _ = receiver.join();
+        },
+    );
+
+    assert_eq!(stats.execs, 1);
+}
+
+#[test]
+fn vec_tag_lexicographic_predicate() {
+    let stats = traceforge::verify(
+        Config::builder()
+            .with_policy(LTR)
+            .with_cons_type(ConsType::FIFO)
+            .build(),
+        || {
+            let receiver = thread::spawn(move || {
+                let low: Msg = traceforge::recv_vec_tagged_msg_block(move |_, tag| {
+                    tag.is_some_and(|t| t < vec![2, 0])
+                });
+                assert_eq!(low, Msg::Val(15));
+
+                let high: Msg = traceforge::recv_vec_tagged_msg_block(move |_, tag| {
+                    tag.is_some_and(|t| t >= vec![2, 0])
+                });
+                assert_eq!(high, Msg::Val(20));
+            });
+
+            traceforge::send_vec_tagged_msg(receiver.thread().id(), vec![2, 0], Msg::Val(20));
+            traceforge::send_vec_tagged_msg(receiver.thread().id(), vec![1, 5], Msg::Val(15));
+
+            let _ = receiver.join();
+        },
+    );
+
+    assert_eq!(stats.execs, 1);
+}


### PR DESCRIPTION
*Description of changes:*

This adds vector tag (`Vec<u32>`) support across send/receive/select APIs, while keeping existing `u32` tag APIs working for backward compatibility.

It adds the following public API functions:
- `send_vec_tagged_msg<T>(t: ThreadId, tag: Vec<u32>, v: T)`
- `send_vec_tagged_lossy_msg<T>(t: ThreadId, tag: Vec<u32>, v: T)`
- `recv_vec_tagged_msg<F, T>(f: F) -> Option<T>`
- `recv_vec_tagged_msg_block<F, T>(f: F) -> T`
- `select_vec_tagged_msg<'a, F, T>(...) -> Option<(T, usize)>`
- `select_vec_tagged_msg_block<'a, F, T>(...) -> (T, usize)`
- `Sender::send_vec_tagged_msg(&self, tag: Vec<u32>, v: T)`
- `Sender::send_vec_tagged_lossy_msg(&self, tag: Vec<u32>, v: T)`
- `Receiver::recv_vec_tagged_msg<F>(&self, f: F) -> Option<T>`
- `Receiver::recv_vec_tagged_msg_block<F>(&self, f: F) -> T`

where `F: Fn(ThreadId, Option<Vec<u32>>) -> bool + 'static + Send + Sync`.

Remark:
- `u32` tag semantic is preserved.
- Empty vector tags are treated as untagged (`None`).  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.