### PR TITLE
fix: Update rand_pcg and rand 0.9 API usage

### DIFF
--- a/traceforge/Cargo.toml
+++ b/traceforge/Cargo.toml
@@ -19,7 +19,7 @@ smallvec = "1.6.1"
 dyn-clone = "1.0.9"
 num_cpus = "1.15"
 rand = "0.9.3"
-rand_pcg = "0.3.1"
+rand_pcg = "0.9"
 exitcode = "1.1.2"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/traceforge/src/lib.rs
+++ b/traceforge/src/lib.rs
@@ -39,7 +39,7 @@ use event_label::{Block, BlockType, CToss, Choice, RecvMsg, SendMsg};
 use loc::{CommunicationModel, Loc, RecvLoc, SendLoc};
 use msg::Message;
 
-use rand::{prelude::*, rngs::OsRng, RngCore};
+use rand::{distr::Distribution, rngs::OsRng, TryRngCore};
 use replay::ReplayInformation;
 use runtime::execution::{Execution, ExecutionState};
 use runtime::failure::persist_task_failure;
@@ -256,7 +256,7 @@ impl ConfigBuilder {
             schedule_policy: SchedulePolicy::LTR,
             max_iterations: None,
             verbose: 0,
-            seed: OsRng.next_u64(),
+            seed: OsRng.try_next_u64().expect("OsRng failed"),
             symmetry: false,
             vr: false,
             lossy_budget: 0,

--- a/traceforge/src/must.rs
+++ b/traceforge/src/must.rs
@@ -12,8 +12,9 @@ use crate::{event_label::*, ExecutionState, MonitorAcceptorFn, MonitorCreateFn};
 use crate::{replay as REPLAY, Val};
 use crate::{Config, ExplorationMode, SchedulePolicy, Stats};
 use log::{debug, info, trace, warn};
-use rand::distributions::Distribution;
-use rand::{prelude::SliceRandom, Rng, SeedableRng};
+use rand::distr::Distribution;
+use rand::seq::IndexedRandom;
+use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg64Mcg;
 
 use core::panic;
@@ -194,7 +195,7 @@ impl Must {
     }
 
     pub(crate) fn gen_bool(&mut self) -> bool {
-        self.rng.gen_range(0..=1) == 0
+        self.rng.random_range(0..=1) == 0
     }
 	 
     pub(crate) fn current() -> Option<Rc<RefCell<Must>>> {
@@ -1063,7 +1064,7 @@ impl Must {
                     self.telemetry
                         .histogram(EXECS_EST.to_owned(), (rfs.len() + 1) as f64);
 
-                    let idx = self.rng.gen_range(0..=rfs.len());
+                    let idx = self.rng.random_range(0..=rfs.len());
 
                     info!("| Choosing {} out of {}", idx, rfs.len());
 
@@ -1092,7 +1093,7 @@ impl Must {
                 self.telemetry
                     .histogram(EXECS_EST.to_owned(), rfs.len() as f64);
 
-                let idx = self.rng.gen_range(0..=(rfs.len() - 1));
+                let idx = self.rng.random_range(0..=(rfs.len() - 1));
 
                 info!("| Choosing {} out of {}", idx, rfs.len());
 
@@ -1488,7 +1489,7 @@ impl Must {
     fn pick_ctoss(&mut self, pos: Event) -> bool {
         self.telemetry.histogram(EXECS_EST.to_owned(), 2.0);
 
-        let toss = rand::thread_rng().gen_range(0..=1) == 0;
+        let toss = rand::rng().random_range(0..=1) == 0;
         cast!(self.current.graph.label_mut(pos), LabelEnum::CToss).set_result(toss);
         toss
     }
@@ -1498,7 +1499,7 @@ impl Must {
         let range = choice.range();
         let start = *range.start();
         let end = *range.end();
-        let rand_value = rand::thread_rng().gen_range(start..=end);
+        let rand_value = rand::rng().random_range(start..=end);
         choice.set_result(rand_value);
 
         self.telemetry
@@ -1515,7 +1516,7 @@ impl Must {
         self.telemetry
             .histogram(EXECS_EST.to_owned(), (revs.len() + 1) as f64);
 
-        let idx = rand::thread_rng().gen_range(0..=revs.len());
+        let idx = rand::rng().random_range(0..=revs.len());
         if idx < revs.len() {
             push_worklist(
                 &mut self.current.rqueue,
@@ -1830,7 +1831,7 @@ fn pop_worklist(worklist: &mut RQueue, is_arbitrary: bool, rng: &mut Pcg64Mcg) -
         }
         else {
             // Choose randomly from alternatives at the highest stamp
-	        let idx = rng.gen_range(0..revs.len());
+	        let idx = rng.random_range(0..revs.len());
 	        let rev = revs.swap_remove(idx);
             (*stamp, rev, revs.is_empty())
         }

--- a/traceforge/tests/estimation.rs
+++ b/traceforge/tests/estimation.rs
@@ -3,7 +3,7 @@ use traceforge::{
     thread::{self, ThreadId},
     Config,
 };
-use rand::distributions::{Bernoulli, Uniform};
+use rand::distr::{Bernoulli, Uniform};
 
 //mod utils;
 
@@ -11,7 +11,7 @@ use rand::distributions::{Bernoulli, Uniform};
 fn sample_basic() {
     let n = 10;
     let stats = traceforge::verify(Config::builder().build(), move || {
-        let s: u32 = traceforge::sample(Uniform::new(0, 100), n);
+        let s: u32 = traceforge::sample(Uniform::new(0, 100).unwrap(), n);
         println!("HERE {s}");
     });
     println!("Stats: {} {}", stats.execs, stats.block);
@@ -22,7 +22,7 @@ fn sample_with_nondet_choice() {
     let n = 10;
     let stats = traceforge::verify(Config::builder().with_verbose(1).build(), move || {
         if traceforge::nondet() {
-            let s: u32 = traceforge::sample(Uniform::new(0, 100), n);
+            let s: u32 = traceforge::sample(Uniform::new(0, 100).unwrap(), n);
             println!("HERE {s}");
         }
     });
@@ -35,12 +35,12 @@ fn sample_with_comm() {
     let stats = traceforge::verify(Config::builder().with_verbose(1).build(), move || {
         let tid = thread::spawn(|| {
             let r: u32 = recv_msg_block();
-            let t: u32 = traceforge::sample(Uniform::new(0, 1), r as usize);
+            let t: u32 = traceforge::sample(Uniform::new(0, 1).unwrap(), r as usize);
             println!("t = {t}");
         })
         .thread()
         .id();
-        let s: u32 = traceforge::sample(Uniform::new(1, 6), n);
+        let s: u32 = traceforge::sample(Uniform::new(1, 6).unwrap(), n);
         send_msg(tid, s);
     });
     println!("Stats: {} {}", stats.execs, stats.block);


### PR DESCRIPTION
fix: Update rand_pcg and rand 0.9 API usage

1. rand_pcg was left at 0.3.1, which depends on rand_core 0.6 and is incompatible with rand 0.9 so Pcg64Mcg no longer satisfies RngCore/Rng, and every RNG call site fails to compile.

2. Several APIs were renamed in rand 0.9 and weren't updated in must.rs, lib.rs, and tests/estimation.rs:
   - rand::distributions → rand::distr
   - rand::thread_rng() → rand::rng()
   - Rng::gen_range → Rng::random_range
   - SliceRandom::choose_multiple now lives behind rand::seq::IndexedRandom
   - OsRng became a fallible TryRngCore (so .next_u64() → .try_next_u64())
   - Uniform::new now returns Result

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
