### PR TITLE
chore: add .gitignore and CI workflow for cargo tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --workspace --all-targets
+
+      - name: Run tests
+        run: cargo test --workspace --all-targets

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.lock
+target/


### PR DESCRIPTION
Summary
- Adds a `.gitignore` excluding `target/` build output and `*.lock` files.
- Adds a GitHub Actions workflow (`.github/workflows/test.yml`) that runs `cargo build` and `cargo test` across the workspace on every push and pull request.

Workflow details
- Triggers: `push` and `pull_request`
- Runner: `ubuntu-latest`
- Toolchain: stable via `dtolnay/rust-toolchain@stable`
- Caching: `Swatinem/rust-cache@v2` for registry + target
- Runs `cargo build --workspace --all-targets` then `cargo test --workspace --all-targets`

Test plan
- CI runs green on this PR
- Workflow triggers on subsequent pushes to the branch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
