### PR TITLE
Add support for concolic execution (ConDpor)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install z3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libz3-dev
+
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
 

--- a/traceforge/Cargo.toml
+++ b/traceforge/Cargo.toml
@@ -32,7 +32,7 @@ dyn-eq = "0.1.3"
 merging-iterator = "1.3.0"
 bytes = "1.10"
 indexmap = "2.12"
-z3 = "0.19"
+z3 = { version = "0.19", optional = true }
 tokio ={ version = "1.50", features = ["full"] }
 rayon = "1.7"
 
@@ -44,7 +44,15 @@ lazy_static = "1.4.0"
 
 [features]
 default = ["print_vals"]
+symbolic = ["dep:z3"]
 print_stamps = []
 print_vals = []
 print_vals_custom = []
 
+[[example]]
+name = "symbolic_echo"
+required-features = ["symbolic"]
+
+[[test]]
+name = "symbolic"
+required-features = ["symbolic"]

--- a/traceforge/Cargo.toml
+++ b/traceforge/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["concurrency", "development-tools::testing"]
 
 version = "0.2.1"
 
-exclude = ['/target' ]
+exclude = ['/target']
 
 [dependencies]
 scoped-tls = "1.0.0"
@@ -25,16 +25,17 @@ futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 paste = "1.0"
-traceforge-macros = { path="../traceforge-macros", version = "0.1" }
+traceforge-macros = { path = "../traceforge-macros", version = "0.1" }
 log = { version = "0.4", features = ["release_max_level_off"] }
 dyn-hash = "0.2.0"
 dyn-eq = "0.1.3"
 merging-iterator = "1.3.0"
 bytes = "1.10"
 indexmap = "2.12"
-tokio ={ version = "1.50", features = ["full"] }
+tokio = { version = "1.50", features = ["full"] }
+z3 = "0.19"
 
-[dev-dependencies] 
+[dev-dependencies]
 serial_test = "3.4.0"
 num-integer = "0.1"
 simplelog = "^0.12.0"

--- a/traceforge/examples/symbolic_echo.rs
+++ b/traceforge/examples/symbolic_echo.rs
@@ -1,0 +1,36 @@
+use traceforge::{recv_msg_block, send_msg, symbolic, thread, verify, Config};
+
+fn example() {
+    let main_id = thread::current_id();
+
+    let worker1 = thread::spawn(move || {
+        let v: symbolic::SymExpr = recv_msg_block();
+        send_msg(main_id, v);
+    });
+
+    let worker2 = thread::spawn(move || {
+        let v: symbolic::SymExpr = recv_msg_block();
+        send_msg(main_id, v);
+    });
+
+    let worker1_id = worker1.thread().id();
+    let worker2_id = worker2.thread().id();
+
+    let b = symbolic::fresh_bool();
+    send_msg(worker1_id, b.clone());
+    send_msg(worker2_id, b);
+
+    let x1: symbolic::SymExpr = recv_msg_block();
+    let x2: symbolic::SymExpr = recv_msg_block();
+
+    assert_eq!(x1, x2);
+    symbolic::assert(x1.eq(x2));
+
+    worker1.join().unwrap();
+    worker2.join().unwrap();
+}
+
+fn main() {
+    let stats = verify(Config::builder().with_symbolic(true).build(), example);
+    println!("Stats = {}, {}", stats.execs, stats.block);
+}

--- a/traceforge/examples/symbolic_echo.rs
+++ b/traceforge/examples/symbolic_echo.rs
@@ -24,7 +24,7 @@ fn example() {
     let x2: symbolic::SymExpr = recv_msg_block();
 
     assert_eq!(x1, x2);
-    symbolic::assert(x1.eq(x2));
+    symbolic::assert(x1.equals(x2));
 
     worker1.join().unwrap();
     worker2.join().unwrap();

--- a/traceforge/src/cons.rs
+++ b/traceforge/src/cons.rs
@@ -192,9 +192,10 @@ impl Consistency {
         check_concurrent: bool,
     ) -> Vec<Event> {
         // Sends that the receive can read from
-        let sends = g.matching_stores(recv.recv_loc())
+        let sends = g
+            .matching_stores(recv.recv_loc())
             // filter-out WakeMsg in our porf prefix: the respective futures were cancelled
-            .filter(|&s| {!s.is_cancelled_wrt(recv.as_event_label())});
+            .filter(|&s| !s.is_cancelled_wrt(recv.as_event_label()));
 
         // Keep those that will exist and be unread after the revisit, checking
         // for concurrent receives.

--- a/traceforge/src/event_label.rs
+++ b/traceforge/src/event_label.rs
@@ -12,6 +12,8 @@ use crate::thread::main_thread_id;
 use crate::vector_clock::VectorClock;
 use crate::ThreadId;
 
+use crate::symbolic::{SymExpr, SymSort, SymVarId};
+
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) enum LabelEnum {
     Begin(Begin),
@@ -25,6 +27,9 @@ pub(crate) enum LabelEnum {
     Choice(Choice),
     Sample(Sample),
     Block(Block),
+
+    SymbolicVar(SymbolicVar),
+    ConstraintEval(ConstraintEval),
 }
 
 macro_rules! match_and_run {
@@ -41,6 +46,9 @@ macro_rules! match_and_run {
             LabelEnum::Choice(l) => l.as_event_label().$name($($arg),*),
             LabelEnum::Sample(l) => l.as_event_label().$name($($arg),*),
             LabelEnum::Block(l) => l.as_event_label().$name($($arg),*),
+
+            LabelEnum::SymbolicVar(l) => l.as_event_label().$name($($arg),*),
+            LabelEnum::ConstraintEval(l) => l.as_event_label().$name($($arg),*),
         }
     };
 }
@@ -59,6 +67,9 @@ macro_rules! match_and_run_mut {
             LabelEnum::Choice(l) => l.as_event_label_mut().$name($($arg),*),
             LabelEnum::Sample(l) => l.as_event_label_mut().$name($($arg),*),
             LabelEnum::Block(l) => l.as_event_label_mut().$name($($arg),*),
+
+            LabelEnum::SymbolicVar(l) => l.as_event_label_mut().$name($($arg),*),
+            LabelEnum::ConstraintEval(l) => l.as_event_label_mut().$name($($arg),*),
         }
     };
 }
@@ -241,6 +252,22 @@ impl LabelEnum {
                     return Ok(());
                 }
             }
+            LabelEnum::SymbolicVar(s) => {
+                if let LabelEnum::SymbolicVar(o) = other {
+                    if s.id != o.id || s.sort != o.sort {
+                        return Err("symbolic variable mismatch".into());
+                    }
+                    return Ok(());
+                }
+            }
+            LabelEnum::ConstraintEval(s) => {
+                if let LabelEnum::ConstraintEval(o) = other {
+                    if s.expr != o.expr || s.kind != o.kind {
+                        return Err("symbolic constraint mismatch".into());
+                    }
+                    return Ok(());
+                }
+            }
         }
 
         if let (LabelEnum::Block(_), LabelEnum::End(_)) = (self, other) {
@@ -288,6 +315,9 @@ impl LabelEnum {
             LabelEnum::Choice(s) => format!("called Range({:?})::nondet", s.range()),
             LabelEnum::Sample(_) => "called sample()".to_string(),
             LabelEnum::Block(_) => "became blocked".to_string(),
+
+            LabelEnum::SymbolicVar(_) => "declared a symbolic variable".to_string(),
+            LabelEnum::ConstraintEval(_) => "evaluated a symbolic expression".to_string(),
         }
     }
 }
@@ -306,6 +336,9 @@ impl fmt::Display for LabelEnum {
             LabelEnum::Choice(lab) => write!(f, "{}", lab),
             LabelEnum::Sample(lab) => write!(f, "{}", lab),
             LabelEnum::Block(lab) => write!(f, "{}", lab),
+
+            LabelEnum::SymbolicVar(lab) => write!(f, "{}", lab),
+            LabelEnum::ConstraintEval(lab) => write!(f, "{}", lab),
         }
     }
 }
@@ -324,6 +357,9 @@ impl fmt::Debug for LabelEnum {
             LabelEnum::Choice(lab) => write!(f, "{}", lab),
             LabelEnum::Sample(lab) => write!(f, "{}", lab),
             LabelEnum::Block(lab) => write!(f, "{}", lab),
+
+            LabelEnum::SymbolicVar(lab) => write!(f, "{}", lab),
+            LabelEnum::ConstraintEval(lab) => write!(f, "{}", lab),
         }
     }
 }
@@ -1164,5 +1200,98 @@ as_label!(Block);
 impl fmt::Display for Block {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}: BLK {:?}", self.as_event_label(), self.btype())
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct SymbolicVar {
+    label: EventLabel,
+    id: SymVarId,
+    sort: SymSort,
+}
+
+impl SymbolicVar {
+    pub(crate) fn new(pos: Event, id: SymVarId, sort: SymSort) -> Self {
+        Self {
+            label: EventLabel::new(pos),
+            id,
+            sort,
+        }
+    }
+
+    pub(crate) fn id(&self) -> SymVarId {
+        self.id
+    }
+    pub(crate) fn sort(&self) -> SymSort {
+        self.sort
+    }
+}
+
+as_label!(SymbolicVar);
+
+impl fmt::Display for SymbolicVar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}: SYM {:?} {:?}",
+            self.as_event_label(),
+            self.id(),
+            self.sort()
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ConstraintKind {
+    Branch,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct ConstraintEval {
+    label: EventLabel,
+    expr: SymExpr,
+    kind: ConstraintKind,
+    branch_taken: bool,
+}
+
+impl ConstraintEval {
+    pub(crate) fn new(pos: Event, expr: SymExpr, kind: ConstraintKind, branch_taken: bool) -> Self {
+        Self {
+            label: EventLabel::new(pos),
+            expr,
+            kind,
+            branch_taken,
+        }
+    }
+
+    pub(crate) fn expr(&self) -> &SymExpr {
+        &self.expr
+    }
+
+    pub(crate) fn kind(&self) -> ConstraintKind {
+        self.kind.clone()
+    }
+
+    pub(crate) fn branch_taken(&self) -> bool {
+        self.branch_taken
+    }
+
+    pub(crate) fn set_branch_taken(&mut self, b: bool) {
+        self.branch_taken = b;
+    }
+}
+
+as_label!(ConstraintEval);
+
+impl fmt::Display for ConstraintEval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}: C-{:?} {:?} [{}]",
+            self.as_event_label(),
+            self.kind(),
+            self.expr(),
+            if self.branch_taken() { "true" } else { "false" }
+        )
     }
 }

--- a/traceforge/src/event_label.rs
+++ b/traceforge/src/event_label.rs
@@ -262,7 +262,7 @@ impl LabelEnum {
             }
             LabelEnum::ConstraintEval(s) => {
                 if let LabelEnum::ConstraintEval(o) = other {
-                    if s.expr != o.expr || s.kind != o.kind {
+                    if s.expr != o.expr {
                         return Err("symbolic constraint mismatch".into());
                     }
                     return Ok(());
@@ -1241,35 +1241,24 @@ impl fmt::Display for SymbolicVar {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ConstraintKind {
-    Branch,
-}
-
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct ConstraintEval {
     label: EventLabel,
     expr: SymExpr,
-    kind: ConstraintKind,
     branch_taken: bool,
 }
 
 impl ConstraintEval {
-    pub(crate) fn new(pos: Event, expr: SymExpr, kind: ConstraintKind, branch_taken: bool) -> Self {
+    pub(crate) fn new(pos: Event, expr: SymExpr, branch_taken: bool) -> Self {
         Self {
             label: EventLabel::new(pos),
             expr,
-            kind,
             branch_taken,
         }
     }
 
     pub(crate) fn expr(&self) -> &SymExpr {
         &self.expr
-    }
-
-    pub(crate) fn kind(&self) -> ConstraintKind {
-        self.kind.clone()
     }
 
     pub(crate) fn branch_taken(&self) -> bool {
@@ -1287,9 +1276,8 @@ impl fmt::Display for ConstraintEval {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}: C-{:?} {:?} [{}]",
+            "{}: C {:?} [{}]",
             self.as_event_label(),
-            self.kind(),
             self.expr(),
             if self.branch_taken() { "true" } else { "false" }
         )

--- a/traceforge/src/event_label.rs
+++ b/traceforge/src/event_label.rs
@@ -1220,7 +1220,7 @@ impl SymbolicVar {
     }
 
     pub(crate) fn id(&self) -> SymVarId {
-        self.id
+        self.id.clone()
     }
     pub(crate) fn sort(&self) -> &SymSort {
         &self.sort

--- a/traceforge/src/event_label.rs
+++ b/traceforge/src/event_label.rs
@@ -13,6 +13,7 @@ use crate::vector_clock::VectorClock;
 use crate::ThreadId;
 use log::debug;
 
+#[cfg(feature = "symbolic")]
 use crate::symbolic::{SymExpr, SymSort, SymVarId};
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -29,7 +30,9 @@ pub(crate) enum LabelEnum {
     Sample(Sample),
     Block(Block),
 
+    #[cfg(feature = "symbolic")]
     SymbolicVar(SymbolicVar),
+    #[cfg(feature = "symbolic")]
     ConstraintEval(ConstraintEval),
 }
 
@@ -48,7 +51,9 @@ macro_rules! match_and_run {
             LabelEnum::Sample(l) => l.as_event_label().$name($($arg),*),
             LabelEnum::Block(l) => l.as_event_label().$name($($arg),*),
 
+            #[cfg(feature = "symbolic")]
             LabelEnum::SymbolicVar(l) => l.as_event_label().$name($($arg),*),
+            #[cfg(feature = "symbolic")]
             LabelEnum::ConstraintEval(l) => l.as_event_label().$name($($arg),*),
         }
     };
@@ -69,7 +74,9 @@ macro_rules! match_and_run_mut {
             LabelEnum::Sample(l) => l.as_event_label_mut().$name($($arg),*),
             LabelEnum::Block(l) => l.as_event_label_mut().$name($($arg),*),
 
+            #[cfg(feature = "symbolic")]
             LabelEnum::SymbolicVar(l) => l.as_event_label_mut().$name($($arg),*),
+            #[cfg(feature = "symbolic")]
             LabelEnum::ConstraintEval(l) => l.as_event_label_mut().$name($($arg),*),
         }
     };
@@ -253,6 +260,7 @@ impl LabelEnum {
                     return Ok(());
                 }
             }
+            #[cfg(feature = "symbolic")]
             LabelEnum::SymbolicVar(s) => {
                 if let LabelEnum::SymbolicVar(o) = other {
                     if s.id != o.id || s.sort != o.sort {
@@ -261,6 +269,7 @@ impl LabelEnum {
                     return Ok(());
                 }
             }
+            #[cfg(feature = "symbolic")]
             LabelEnum::ConstraintEval(s) => {
                 if let LabelEnum::ConstraintEval(o) = other {
                     if s.expr != o.expr {
@@ -317,7 +326,9 @@ impl LabelEnum {
             LabelEnum::Sample(_) => "called sample()".to_string(),
             LabelEnum::Block(_) => "became blocked".to_string(),
 
+            #[cfg(feature = "symbolic")]
             LabelEnum::SymbolicVar(_) => "declared a symbolic variable".to_string(),
+            #[cfg(feature = "symbolic")]
             LabelEnum::ConstraintEval(_) => "evaluated a symbolic expression".to_string(),
         }
     }
@@ -338,7 +349,9 @@ impl fmt::Display for LabelEnum {
             LabelEnum::Sample(lab) => write!(f, "{}", lab),
             LabelEnum::Block(lab) => write!(f, "{}", lab),
 
+            #[cfg(feature = "symbolic")]
             LabelEnum::SymbolicVar(lab) => write!(f, "{}", lab),
+            #[cfg(feature = "symbolic")]
             LabelEnum::ConstraintEval(lab) => write!(f, "{}", lab),
         }
     }
@@ -359,7 +372,9 @@ impl fmt::Debug for LabelEnum {
             LabelEnum::Sample(lab) => write!(f, "{}", lab),
             LabelEnum::Block(lab) => write!(f, "{}", lab),
 
+            #[cfg(feature = "symbolic")]
             LabelEnum::SymbolicVar(lab) => write!(f, "{}", lab),
+            #[cfg(feature = "symbolic")]
             LabelEnum::ConstraintEval(lab) => write!(f, "{}", lab),
         }
     }
@@ -1261,6 +1276,7 @@ impl fmt::Display for Block {
     }
 }
 
+#[cfg(feature = "symbolic")]
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct SymbolicVar {
     label: EventLabel,
@@ -1268,6 +1284,7 @@ pub(crate) struct SymbolicVar {
     sort: SymSort,
 }
 
+#[cfg(feature = "symbolic")]
 impl SymbolicVar {
     pub(crate) fn new(pos: Event, id: SymVarId, sort: SymSort) -> Self {
         Self {
@@ -1285,8 +1302,10 @@ impl SymbolicVar {
     }
 }
 
+#[cfg(feature = "symbolic")]
 as_label!(SymbolicVar);
 
+#[cfg(feature = "symbolic")]
 impl fmt::Display for SymbolicVar {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -1299,6 +1318,7 @@ impl fmt::Display for SymbolicVar {
     }
 }
 
+#[cfg(feature = "symbolic")]
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct ConstraintEval {
     label: EventLabel,
@@ -1306,6 +1326,7 @@ pub(crate) struct ConstraintEval {
     branch_taken: bool,
 }
 
+#[cfg(feature = "symbolic")]
 impl ConstraintEval {
     pub(crate) fn new(pos: Event, expr: SymExpr, branch_taken: bool) -> Self {
         Self {
@@ -1328,8 +1349,10 @@ impl ConstraintEval {
     }
 }
 
+#[cfg(feature = "symbolic")]
 as_label!(ConstraintEval);
 
+#[cfg(feature = "symbolic")]
 impl fmt::Display for ConstraintEval {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(

--- a/traceforge/src/event_label.rs
+++ b/traceforge/src/event_label.rs
@@ -1222,8 +1222,8 @@ impl SymbolicVar {
     pub(crate) fn id(&self) -> SymVarId {
         self.id
     }
-    pub(crate) fn sort(&self) -> SymSort {
-        self.sort
+    pub(crate) fn sort(&self) -> &SymSort {
+        &self.sort
     }
 }
 

--- a/traceforge/src/exec_graph.rs
+++ b/traceforge/src/exec_graph.rs
@@ -415,8 +415,6 @@ impl ExecutionGraph {
         }
         ret
     }
-	 
-	
 
     /// Add a label to the graph, giving it a new stamp if it does not have one.
     pub(crate) fn add_label(&mut self, lab: LabelEnum) -> Event {

--- a/traceforge/src/lib.rs
+++ b/traceforge/src/lib.rs
@@ -29,6 +29,7 @@ mod testmode;
 use future::spawn_receive;
 pub use testmode::{parallel_test, test};
 
+#[cfg(feature = "symbolic")]
 pub mod symbolic;
 pub mod thread;
 mod vector_clock;
@@ -247,6 +248,7 @@ pub struct Config {
     #[serde(skip)]
     pub(crate) callbacks: Arc<Mutex<Vec<Box<dyn ExecutionObserver + Send>>>>,
 
+    #[cfg(feature = "symbolic")]
     pub(crate) symbolic: bool,
 }
 
@@ -317,6 +319,7 @@ impl ConfigBuilder {
             predetermined_global_choices: HashMap::new(),
             pretty_graph_printing: false,
             callbacks: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(feature = "symbolic")]
             symbolic: false,
         })
     }
@@ -327,6 +330,7 @@ impl ConfigBuilder {
         if self.0.symmetry {
             panic!("Symmetry reduction is currently not supported")
         }
+        #[cfg(feature = "symbolic")]
         if self.0.symbolic && self.0.parallel {
             panic!("Symbolic/Condpor is not supported with parallel exploration yet");
         }
@@ -594,6 +598,7 @@ impl ConfigBuilder {
     }
 
     /// Enables the symbolic (concolic) support (as in `condpor`).
+    #[cfg(feature = "symbolic")]
     pub fn with_symbolic(mut self, enabled: bool) -> Self {
         self.0.symbolic = enabled;
         self

--- a/traceforge/src/lib.rs
+++ b/traceforge/src/lib.rs
@@ -27,6 +27,7 @@ mod testmode;
 use future::spawn_receive;
 pub use testmode::{parallel_test, test};
 
+pub mod symbolic;
 pub mod thread;
 mod vector_clock;
 
@@ -208,6 +209,8 @@ pub struct Config {
     pub(crate) predetermined_choices: HashMap<String, Vec<Vec<bool>>>,
     #[serde(skip)]
     pub(crate) callbacks: Arc<Mutex<Vec<Box<dyn ExecutionObserver + Send>>>>,
+
+    pub(crate) symbolic: bool,
 }
 
 impl Config {
@@ -269,6 +272,7 @@ impl ConfigBuilder {
             keep_per_execution_coverage: false,
             predetermined_choices: HashMap::new(),
             callbacks: Arc::new(Mutex::new(Vec::new())),
+            symbolic: false,
         })
     }
 
@@ -277,6 +281,9 @@ impl ConfigBuilder {
     fn check_valid(self) -> Self {
         if self.0.symmetry {
             panic!("Symmetry reduction is currently not supported")
+        }
+        if self.0.symbolic && self.0.parallel {
+            panic!("Symbolic/Condpor is not supported with parallel exploration yet");
         }
         if self.0.symmetry && self.0.schedule_policy == SchedulePolicy::Arbitrary {
             eprintln!("Symmetry reduction can only be used with LTR!");
@@ -486,6 +493,12 @@ impl ConfigBuilder {
     /// ```
     pub fn with_predetermined_choices(mut self, choices: HashMap<String, Vec<Vec<bool>>>) -> Self {
         self.0.predetermined_choices = choices;
+        self
+    }
+
+    /// Enables the symbolic (concolic) support (as in `condpor`).
+    pub fn with_symbolic(mut self, enabled: bool) -> Self {
+        self.0.symbolic = enabled;
         self
     }
 
@@ -788,9 +801,13 @@ where
     T: Message + 'static,
 {
     let locs = recvs.map(|r| &r.inner);
-    recv_msg_with_tag(locs, comm, Some(PredicateType(Arc::new(move |tid, tag| {
-        f(tid, normalize_vec_tag(tag))
-    }))))
+    recv_msg_with_tag(
+        locs,
+        comm,
+        Some(PredicateType(Arc::new(move |tid, tag| {
+            f(tid, normalize_vec_tag(tag))
+        }))),
+    )
 }
 
 pub fn select_msg_block<'a, T: Message + 'static>(
@@ -826,9 +843,13 @@ where
     T: Message + 'static,
 {
     let locs = recvs.map(|r| &r.inner);
-    recv_msg_block_with_tag(locs, comm, Some(PredicateType(Arc::new(move |tid, tag| {
-        f(tid, normalize_vec_tag(tag))
-    }))))
+    recv_msg_block_with_tag(
+        locs,
+        comm,
+        Some(PredicateType(Arc::new(move |tid, tag| {
+            f(tid, normalize_vec_tag(tag))
+        }))),
+    )
 }
 
 // Main API

--- a/traceforge/src/must.rs
+++ b/traceforge/src/must.rs
@@ -759,18 +759,16 @@ impl Must {
     }
 
     pub(crate) fn handle_constraint_eval(&mut self, mut lab: ConstraintEval) -> bool {
-        let pos = lab.pos();
+        if self.is_replay(lab.pos()) {
+            let pos = lab.pos();
 
-        if self.is_replay(pos) {
             let stored = match self.current.graph.label(pos).clone() {
                 LabelEnum::ConstraintEval(c) => c,
                 other => panic!("expected constraint at {}, got {}", pos, other),
             };
 
-            self.current
-                .graph
-                .validate_replay_event(&LabelEnum::ConstraintEval(lab));
-
+            let lab = LabelEnum::ConstraintEval(lab.clone());
+            self.current.graph.validate_replay_event(&lab);
             self.process_event(LabelEnum::ConstraintEval(stored.clone()));
             self.add_constraint_to_path_solver(&stored);
             return stored.branch_taken();
@@ -847,10 +845,6 @@ impl Must {
     }
 
     fn is_maximal_constraint(&self, c: &ConstraintEval, rev: &Revisit) -> bool {
-        if c.kind() != ConstraintKind::Branch {
-            return true;
-        }
-
         let view = self.current.graph.revisit_view(rev);
         let mut g = self.current.graph.copy_to_view(&view);
         g.change_rf(rev.pos, Some(rev.rev));
@@ -1577,7 +1571,6 @@ impl Must {
                 self.current.graph.incr_dropped_sends();
             }
             LabelEnum::ConstraintEval(c) => {
-                assert_eq!(c.kind(), ConstraintKind::Branch);
                 c.set_branch_taken(!c.branch_taken());
             }
             _ => panic!(),

--- a/traceforge/src/must.rs
+++ b/traceforge/src/must.rs
@@ -28,6 +28,8 @@ use std::time::Instant;
 use crate::msg::Message;
 use crate::thread::{main_thread_id, ThreadId};
 
+use crate::symbolic::{SymVarId, SymbolicSolver};
+
 use crate::monitor_types::{EndCondition, ExecutionEnd, Monitor, MonitorResult};
 use std::any::TypeId;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
@@ -134,6 +136,10 @@ pub(crate) struct Must {
     pub(crate) next_thread_index: HashMap<String, usize>,
     // Per-execution counters: (choice_name, thread_idx) -> occurrence count
     pub(crate) choice_occurrence_counters: HashMap<(String, usize), usize>,
+    // Next available index for symbolic variable
+    pub(crate) next_sym_var: u64,
+    // Solver for the symbolic constraints in the current execution.
+    symbolic_solver: SymbolicSolver,
 }
 
 impl Must {
@@ -167,6 +173,8 @@ impl Must {
             thread_index_map: HashMap::new(),
             next_thread_index: HashMap::new(),
             choice_occurrence_counters: HashMap::new(),
+            next_sym_var: 1,
+            symbolic_solver: SymbolicSolver::new(),
         }
     }
 
@@ -191,13 +199,14 @@ impl Must {
         self.thread_index_map.clear();
         self.next_thread_index.clear();
         self.choice_occurrence_counters.clear();
-
+        self.next_sym_var = 1;
+        self.symbolic_solver.reset();
     }
 
     pub(crate) fn gen_bool(&mut self) -> bool {
         self.rng.random_range(0..=1) == 0
     }
-	 
+
     pub(crate) fn current() -> Option<Rc<RefCell<Must>>> {
         CURRENT_MUST.with(|current_must| current_must.borrow().clone())
     }
@@ -210,6 +219,8 @@ impl Must {
 
     pub(crate) fn begin_execution(must: &Rc<RefCell<Must>>) {
         let mut must = must.borrow_mut();
+        must.next_sym_var = 1;
+        must.symbolic_solver.reset();
         must.current.graph.initialize_for_execution();
         must.telemetry.coverage.new_eid();
 
@@ -301,6 +312,13 @@ impl Must {
         self.current.rqueue.clear();
         self.states.clear();
         self.current.graph = eg;
+        self.symbolic_solver.reset();
+    }
+
+    pub(crate) fn next_symbolic_var_id(&mut self) -> SymVarId {
+        let id = SymVarId(self.next_sym_var);
+        self.next_sym_var += 1;
+        id
     }
 
     /// Add the replay information to a fresh instance of Must
@@ -425,7 +443,9 @@ impl Must {
             };
             // The reader might be stuck waiting us, inform caller
             // to handle appropriately (has access to ExecutionState).
-            if let Some(r) = slab.reader() { stuck.push(r) }
+            if let Some(r) = slab.reader() {
+                stuck.push(r)
+            }
             // Similar for monitor readers
             slab.monitor_readers().iter().for_each(|&r| stuck.push(r));
             return stuck;
@@ -626,7 +646,7 @@ impl Must {
         self.add_to_graph(LabelEnum::CToss(ctlab));
         // Note: We don't add a revisit here because the value is predetermined
         value
-    }    
+    }
 
     pub(crate) fn handle_choice(&mut self, chlab: Choice) -> usize {
         let result = chlab.result();
@@ -725,6 +745,129 @@ impl Must {
             );
         }
         first
+    }
+
+    pub(crate) fn handle_symbolic_var(&mut self, lab: SymbolicVar) {
+        if self.is_replay(lab.pos()) {
+            let actual = LabelEnum::SymbolicVar(lab);
+            self.current.graph.validate_replay_event(&actual);
+            self.process_event(actual);
+            return;
+        }
+
+        self.add_to_graph(LabelEnum::SymbolicVar(lab));
+    }
+
+    pub(crate) fn handle_constraint_eval(&mut self, mut lab: ConstraintEval) -> bool {
+        let pos = lab.pos();
+
+        if self.is_replay(pos) {
+            let stored = match self.current.graph.label(pos).clone() {
+                LabelEnum::ConstraintEval(c) => c,
+                other => panic!("expected constraint at {}, got {}", pos, other),
+            };
+
+            self.current
+                .graph
+                .validate_replay_event(&LabelEnum::ConstraintEval(lab));
+
+            self.process_event(LabelEnum::ConstraintEval(stored.clone()));
+            self.add_constraint_to_path_solver(&stored);
+            return stored.branch_taken();
+        }
+
+        let true_sat = self.symbolic_solver.sat_with(lab.expr());
+        let false_sat = self.symbolic_solver.sat_with_not(lab.expr());
+
+        if !true_sat && !false_sat {
+            self.add_to_graph(LabelEnum::ConstraintEval(lab));
+            self.stop();
+            return false;
+        }
+
+        let chosen = true_sat;
+        lab.set_branch_taken(chosen);
+
+        let pos = self.add_to_graph(LabelEnum::ConstraintEval(lab.clone()));
+        self.add_constraint_to_path_solver(&lab);
+
+        if true_sat && false_sat {
+            push_worklist(
+                &mut self.current.rqueue,
+                self.current.graph.label(pos).stamp(),
+                RevisitEnum::new_forward(pos, Event::new_init()),
+            );
+        }
+
+        chosen
+    }
+
+    fn add_constraint_to_path_solver(&mut self, c: &ConstraintEval) {
+        if c.branch_taken() {
+            self.symbolic_solver.assert(c.expr());
+        } else {
+            self.symbolic_solver.assert_not(c.expr());
+        }
+    }
+
+    fn symbolic_solver_for_graph(&self, g: &ExecutionGraph) -> SymbolicSolver {
+        let mut solver = SymbolicSolver::new();
+
+        let mut labels = g
+            .threads
+            .iter()
+            .flat_map(|t| t.labels.iter())
+            .collect::<Vec<_>>();
+
+        labels.sort_by_key(|lab| lab.stamp());
+
+        for lab in labels {
+            if let LabelEnum::ConstraintEval(c) = lab {
+                if c.branch_taken() {
+                    solver.assert(c.expr());
+                } else {
+                    solver.assert_not(c.expr());
+                }
+            }
+        }
+
+        solver
+    }
+
+    fn symbolic_backward_revisit_is_sat(&self, rev: &Revisit) -> bool {
+        if !self.config.symbolic {
+            return true;
+        }
+
+        let view = self.current.graph.revisit_view(rev);
+        let mut g = self.current.graph.copy_to_view(&view);
+        g.change_rf(rev.pos, Some(rev.rev));
+
+        self.symbolic_solver_for_graph(&g).is_sat()
+    }
+
+    fn is_maximal_constraint(&self, c: &ConstraintEval, rev: &Revisit) -> bool {
+        if c.kind() != ConstraintKind::Branch {
+            return true;
+        }
+
+        let view = self.current.graph.revisit_view(rev);
+        let mut g = self.current.graph.copy_to_view(&view);
+        g.change_rf(rev.pos, Some(rev.rev));
+
+        let solver = self.symbolic_solver_for_graph(&g);
+
+        let true_sat = solver.sat_with(c.expr());
+        if true_sat {
+            return c.branch_taken();
+        }
+
+        let false_sat = solver.sat_with_not(c.expr());
+        if false_sat {
+            return !c.branch_taken();
+        }
+
+        false
     }
 
     // this checks if the current graph is consistent
@@ -865,7 +1008,7 @@ impl Must {
     /// Check if the execution is blocked. Return None if it's not blocked, or Some(Block)
     /// to tell why it is blocked.
     fn check_blocked(&mut self) -> Option<BlockType> {
-        self.current.graph.check_blocked()    
+        self.current.graph.check_blocked()
     }
 
     /// `complete_execution` is invoked when a particular single execution has finished.
@@ -1044,7 +1187,7 @@ impl Must {
         }
 
         // Clean up per-execution coverage data after observers have been notified
-	    self.telemetry.coverage.cleanup_current_execution();
+        self.telemetry.coverage.cleanup_current_execution();
     }
 
     fn visit_rfs(&mut self, pos: Event, blocking: bool) -> Option<Val> {
@@ -1179,6 +1322,8 @@ impl Must {
                 self.checker
                     .is_revisit_consistent(g, rlab, slab, self.is_monitor(&rlab.pos()))
             })
+            // Filter out non maximal revisit w.r.t. condpor
+            .filter(|rlab| self.symbolic_backward_revisit_is_sat(&Revisit::new(rlab.pos(), pos)))
             // And again, take while the revisit is maximal (deeper revisits are futile if this fails)
             .take_while(|&rlab| self.is_maximal_extension(&Revisit::new(rlab.pos(), pos)))
             .map(|recv| recv.pos())
@@ -1243,6 +1388,8 @@ impl Must {
             // we handle this via the revisitable flag on the corresponding receive.
             LabelEnum::SendMsg(slab) => !slab.is_dropped(),
             LabelEnum::Choice(chlab) => chlab.result() == *chlab.range().end(),
+            LabelEnum::ConstraintEval(c) => self.is_maximal_constraint(c, rev),
+            LabelEnum::SymbolicVar(_) => true,
             _ => true,
         }
     }
@@ -1370,7 +1517,13 @@ impl Must {
                 }
                 return false;
             }
-            let rev = { pop_worklist(&mut self.current.rqueue, self.config.schedule_policy == SchedulePolicy::Arbitrary, &mut self.rng) };
+            let rev = {
+                pop_worklist(
+                    &mut self.current.rqueue,
+                    self.config.schedule_policy == SchedulePolicy::Arbitrary,
+                    &mut self.rng,
+                )
+            };
             if self.config.verbose >= 3 {
                 println!("Revisit {} <= {}", rev.pos(), rev.rev());
                 println!("Before graph:");
@@ -1422,6 +1575,10 @@ impl Must {
             LabelEnum::SendMsg(slab) => {
                 slab.set_dropped();
                 self.current.graph.incr_dropped_sends();
+            }
+            LabelEnum::ConstraintEval(c) => {
+                assert_eq!(c.kind(), ConstraintKind::Branch);
+                c.set_branch_taken(!c.branch_taken());
             }
             _ => panic!(),
         };
@@ -1825,14 +1982,13 @@ fn pop_worklist(worklist: &mut RQueue, is_arbitrary: bool, rng: &mut Pcg64Mcg) -
             .iter_mut()
             .next_back()
             .expect("worklist is not empty");
-        if !is_arbitrary  {
+        if !is_arbitrary {
             let rev = revs.pop().unwrap();
             (*stamp, rev, revs.is_empty())
-        }
-        else {
+        } else {
             // Choose randomly from alternatives at the highest stamp
-	        let idx = rng.random_range(0..revs.len());
-	        let rev = revs.swap_remove(idx);
+            let idx = rng.random_range(0..revs.len());
+            let rev = revs.swap_remove(idx);
             (*stamp, rev, revs.is_empty())
         }
     };

--- a/traceforge/src/must.rs
+++ b/traceforge/src/must.rs
@@ -136,8 +136,6 @@ pub(crate) struct Must {
     pub(crate) next_thread_index: HashMap<String, usize>,
     // Per-execution counters: (choice_name, thread_idx) -> occurrence count
     pub(crate) choice_occurrence_counters: HashMap<(String, usize), usize>,
-    // Next available index for symbolic variable
-    pub(crate) next_sym_var: u64,
     // Solver for the symbolic constraints in the current execution.
     symbolic_solver: SymbolicSolver,
 }
@@ -173,7 +171,6 @@ impl Must {
             thread_index_map: HashMap::new(),
             next_thread_index: HashMap::new(),
             choice_occurrence_counters: HashMap::new(),
-            next_sym_var: 1,
             symbolic_solver: SymbolicSolver::new(),
         }
     }
@@ -199,7 +196,6 @@ impl Must {
         self.thread_index_map.clear();
         self.next_thread_index.clear();
         self.choice_occurrence_counters.clear();
-        self.next_sym_var = 1;
         self.symbolic_solver.reset();
     }
 
@@ -219,7 +215,6 @@ impl Must {
 
     pub(crate) fn begin_execution(must: &Rc<RefCell<Must>>) {
         let mut must = must.borrow_mut();
-        must.next_sym_var = 1;
         must.symbolic_solver.reset();
         must.current.graph.initialize_for_execution();
         must.telemetry.coverage.new_eid();
@@ -313,12 +308,6 @@ impl Must {
         self.states.clear();
         self.current.graph = eg;
         self.symbolic_solver.reset();
-    }
-
-    pub(crate) fn next_symbolic_var_id(&mut self) -> SymVarId {
-        let id = SymVarId(self.next_sym_var);
-        self.next_sym_var += 1;
-        id
     }
 
     /// Add the replay information to a fresh instance of Must

--- a/traceforge/src/must.rs
+++ b/traceforge/src/must.rs
@@ -28,7 +28,7 @@ use std::time::Instant;
 use crate::msg::Message;
 use crate::thread::{main_thread_id, ThreadId};
 
-use crate::symbolic::{SymVarId, SymbolicSolver};
+use crate::symbolic::SymbolicSolver;
 
 use crate::monitor_types::{EndCondition, ExecutionEnd, Monitor, MonitorResult};
 use std::any::TypeId;

--- a/traceforge/src/must.rs
+++ b/traceforge/src/must.rs
@@ -778,9 +778,10 @@ impl Must {
         let false_sat = self.symbolic_solver.sat_with_not(lab.expr());
 
         if !true_sat && !false_sat {
-            self.add_to_graph(LabelEnum::ConstraintEval(lab));
-            self.stop();
-            return false;
+            panic!(
+                "both a constraint and its negation are unsatisfiable for {:?}",
+                lab.expr()
+            );
         }
 
         let chosen = true_sat;

--- a/traceforge/src/must.rs
+++ b/traceforge/src/must.rs
@@ -29,6 +29,7 @@ use std::time::Instant;
 use crate::msg::Message;
 use crate::thread::{main_thread_id, ThreadId};
 
+#[cfg(feature = "symbolic")]
 use crate::symbolic::SymbolicSolver;
 
 use crate::monitor_types::{EndCondition, ExecutionEnd, Monitor, MonitorResult};
@@ -140,6 +141,7 @@ pub(crate) struct Must {
     pub(crate) next_thread_index: HashMap<String, usize>,
     // Per-execution counters: (choice_name, thread_idx) -> occurrence count
     pub(crate) choice_occurrence_counters: HashMap<(String, usize), usize>,
+    #[cfg(feature = "symbolic")]
     // Solver for the symbolic constraints in the current execution.
     symbolic_solver: SymbolicSolver,
     // Cache for global named choices: once resolved, the same value is returned for all threads
@@ -179,6 +181,7 @@ impl Must {
             thread_index_map: HashMap::new(),
             next_thread_index: HashMap::new(),
             choice_occurrence_counters: HashMap::new(),
+            #[cfg(feature = "symbolic")]
             symbolic_solver: SymbolicSolver::new(),
             global_named_choices: HashMap::new(),
             max_graph_events: 0,
@@ -206,6 +209,7 @@ impl Must {
         self.thread_index_map.clear();
         self.next_thread_index.clear();
         self.choice_occurrence_counters.clear();
+        #[cfg(feature = "symbolic")]
         self.symbolic_solver.reset();
         self.global_named_choices.clear();
 
@@ -227,6 +231,7 @@ impl Must {
 
     pub(crate) fn begin_execution(must: &Rc<RefCell<Must>>) {
         let mut must = must.borrow_mut();
+        #[cfg(feature = "symbolic")]
         must.symbolic_solver.reset();
         must.current.graph.initialize_for_execution();
         must.telemetry.coverage.new_eid();
@@ -320,6 +325,7 @@ impl Must {
         self.current.rqueue.clear();
         self.states.clear();
         self.current.graph = eg;
+        #[cfg(feature = "symbolic")]
         self.symbolic_solver.reset();
     }
 
@@ -911,6 +917,7 @@ impl Must {
         first
     }
 
+    #[cfg(feature = "symbolic")]
     pub(crate) fn handle_symbolic_var(&mut self, lab: SymbolicVar) {
         if self.is_replay(lab.pos()) {
             let actual = LabelEnum::SymbolicVar(lab);
@@ -922,6 +929,7 @@ impl Must {
         self.add_to_graph(LabelEnum::SymbolicVar(lab));
     }
 
+    #[cfg(feature = "symbolic")]
     pub(crate) fn handle_constraint_eval(&mut self, mut lab: ConstraintEval) -> bool {
         if self.is_replay(lab.pos()) {
             let pos = lab.pos();
@@ -965,6 +973,7 @@ impl Must {
         chosen
     }
 
+    #[cfg(feature = "symbolic")]
     fn add_constraint_to_path_solver(&mut self, c: &ConstraintEval) {
         if c.branch_taken() {
             self.symbolic_solver.assert(c.expr());
@@ -973,6 +982,7 @@ impl Must {
         }
     }
 
+    #[cfg(feature = "symbolic")]
     fn symbolic_solver_for_graph(&self, g: &ExecutionGraph) -> SymbolicSolver {
         let mut solver = SymbolicSolver::new();
 
@@ -997,6 +1007,7 @@ impl Must {
         solver
     }
 
+    #[cfg(feature = "symbolic")]
     fn symbolic_backward_revisit_is_sat(&self, rev: &Revisit) -> bool {
         if !self.config.symbolic {
             return true;
@@ -1009,6 +1020,7 @@ impl Must {
         self.symbolic_solver_for_graph(&g).is_sat()
     }
 
+    #[cfg(feature = "symbolic")]
     fn is_maximal_constraint(&self, c: &ConstraintEval, rev: &Revisit) -> bool {
         let view = self.current.graph.revisit_view(rev);
         let mut g = self.current.graph.copy_to_view(&view);
@@ -1509,8 +1521,17 @@ impl Must {
                 self.checker
                     .is_revisit_consistent(g, rlab, slab, self.is_monitor(&rlab.pos()))
             })
+            .collect::<Vec<_>>();
+
+        #[cfg(feature = "symbolic")]
+        let revs = revs
+            .into_iter()
             // Filter out non maximal revisit w.r.t. condpor
             .filter(|rlab| self.symbolic_backward_revisit_is_sat(&Revisit::new(rlab.pos(), pos)))
+            .collect::<Vec<_>>();
+
+        let revs = revs
+            .into_iter()
             // And again, take while the revisit is maximal (deeper revisits are futile if this fails)
             .take_while(|&rlab| self.is_maximal_extension(&Revisit::new(rlab.pos(), pos)))
             .map(|recv| recv.pos())
@@ -1579,7 +1600,9 @@ impl Must {
             // we handle this via the revisitable flag on the corresponding receive.
             LabelEnum::SendMsg(slab) => !slab.is_dropped(),
             LabelEnum::Choice(chlab) => chlab.result() == *chlab.range().end(),
+            #[cfg(feature = "symbolic")]
             LabelEnum::ConstraintEval(c) => self.is_maximal_constraint(c, rev),
+            #[cfg(feature = "symbolic")]
             LabelEnum::SymbolicVar(_) => true,
             _ => true,
         }
@@ -1768,6 +1791,7 @@ impl Must {
                 slab.set_dropped();
                 self.current.graph.incr_dropped_sends();
             }
+            #[cfg(feature = "symbolic")]
             LabelEnum::ConstraintEval(c) => {
                 c.set_branch_taken(!c.branch_taken());
             }

--- a/traceforge/src/symbolic/expr.rs
+++ b/traceforge/src/symbolic/expr.rs
@@ -1,0 +1,226 @@
+use serde::{Deserialize, Serialize};
+use std::ops::{Add, Div, Mul, Rem, Sub};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SymVarId(pub u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SymSort {
+    Bool,
+    Int,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SymExpr {
+    Var { id: SymVarId, sort: SymSort },
+    Bool(bool),
+    Int(i64),
+    Not(Box<SymExpr>),
+    And(Box<SymExpr>, Box<SymExpr>),
+    Or(Box<SymExpr>, Box<SymExpr>),
+    Implies(Box<SymExpr>, Box<SymExpr>),
+    Eq(Box<SymExpr>, Box<SymExpr>),
+    Gt(Box<SymExpr>, Box<SymExpr>),
+    Ge(Box<SymExpr>, Box<SymExpr>),
+    Lt(Box<SymExpr>, Box<SymExpr>),
+    Le(Box<SymExpr>, Box<SymExpr>),
+    Add(Box<SymExpr>, Box<SymExpr>),
+    Sub(Box<SymExpr>, Box<SymExpr>),
+    Mul(Box<SymExpr>, Box<SymExpr>),
+    Div(Box<SymExpr>, Box<SymExpr>),
+    Rem(Box<SymExpr>, Box<SymExpr>),
+}
+
+impl SymExpr {
+    pub fn not(self) -> Self {
+        SymExpr::Not(Box::new(self))
+    }
+
+    pub fn and(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::And(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn or(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Or(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn implies(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Implies(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn eq(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Eq(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn gt(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Gt(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn ge(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Ge(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn lt(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Lt(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn le(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Le(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn sub(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Sub(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn mult(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Mul(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn div(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Div(Box::new(self), Box::new(other.into()))
+    }
+
+    pub fn rem(self, other: impl Into<SymExpr>) -> Self {
+        SymExpr::Rem(Box::new(self), Box::new(other.into()))
+    }
+}
+
+pub fn int_val(v: i64) -> SymExpr {
+    SymExpr::Int(v)
+}
+
+pub fn bool_val(v: bool) -> SymExpr {
+    SymExpr::Bool(v)
+}
+
+impl From<i64> for SymExpr {
+    fn from(value: i64) -> Self {
+        int_val(value)
+    }
+}
+
+impl From<bool> for SymExpr {
+    fn from(value: bool) -> Self {
+        bool_val(value)
+    }
+}
+
+impl Add for SymExpr {
+    type Output = SymExpr;
+
+    fn add(self, rhs: SymExpr) -> Self::Output {
+        SymExpr::Add(Box::new(self), Box::new(rhs))
+    }
+}
+
+impl Add<i64> for SymExpr {
+    type Output = SymExpr;
+
+    fn add(self, rhs: i64) -> Self::Output {
+        self + int_val(rhs)
+    }
+}
+
+impl Add<SymExpr> for i64 {
+    type Output = SymExpr;
+
+    fn add(self, rhs: SymExpr) -> Self::Output {
+        int_val(self) + rhs
+    }
+}
+
+impl Sub for SymExpr {
+    type Output = SymExpr;
+
+    fn sub(self, rhs: SymExpr) -> Self::Output {
+        SymExpr::Sub(Box::new(self), Box::new(rhs))
+    }
+}
+
+impl Sub<i64> for SymExpr {
+    type Output = SymExpr;
+
+    fn sub(self, rhs: i64) -> Self::Output {
+        self - int_val(rhs)
+    }
+}
+
+impl Sub<SymExpr> for i64 {
+    type Output = SymExpr;
+
+    fn sub(self, rhs: SymExpr) -> Self::Output {
+        int_val(self) - rhs
+    }
+}
+
+impl Mul for SymExpr {
+    type Output = SymExpr;
+
+    fn mul(self, rhs: SymExpr) -> Self::Output {
+        SymExpr::Mul(Box::new(self), Box::new(rhs))
+    }
+}
+
+impl Mul<i64> for SymExpr {
+    type Output = SymExpr;
+
+    fn mul(self, rhs: i64) -> Self::Output {
+        self * int_val(rhs)
+    }
+}
+
+impl Mul<SymExpr> for i64 {
+    type Output = SymExpr;
+
+    fn mul(self, rhs: SymExpr) -> Self::Output {
+        int_val(self) * rhs
+    }
+}
+
+impl Div for SymExpr {
+    type Output = SymExpr;
+
+    fn div(self, rhs: SymExpr) -> Self::Output {
+        SymExpr::Div(Box::new(self), Box::new(rhs))
+    }
+}
+
+impl Div<i64> for SymExpr {
+    type Output = SymExpr;
+
+    fn div(self, rhs: i64) -> Self::Output {
+        self / int_val(rhs)
+    }
+}
+
+impl Div<SymExpr> for i64 {
+    type Output = SymExpr;
+
+    fn div(self, rhs: SymExpr) -> Self::Output {
+        int_val(self) / rhs
+    }
+}
+
+impl Rem for SymExpr {
+    type Output = SymExpr;
+
+    fn rem(self, rhs: SymExpr) -> Self::Output {
+        SymExpr::Rem(Box::new(self), Box::new(rhs))
+    }
+}
+
+impl Rem<i64> for SymExpr {
+    type Output = SymExpr;
+
+    fn rem(self, rhs: i64) -> Self::Output {
+        self % int_val(rhs)
+    }
+}
+
+impl Rem<SymExpr> for i64 {
+    type Output = SymExpr;
+
+    fn rem(self, rhs: SymExpr) -> Self::Output {
+        int_val(self) % rhs
+    }
+}

--- a/traceforge/src/symbolic/expr.rs
+++ b/traceforge/src/symbolic/expr.rs
@@ -1,6 +1,8 @@
 use crate::event::Event;
 use serde::{Deserialize, Serialize};
+use std::cell::Cell;
 use std::ops::{Add, Div, Mul, Rem, Sub};
+use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SymVarId(Event);
@@ -58,9 +60,9 @@ impl SymFunc {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BoundVarId {
-    depth: usize,
+    scope: usize,
     index: usize,
 }
 
@@ -74,10 +76,14 @@ pub struct BoundVar {
 impl BoundVar {
     pub fn expr(&self) -> SymExpr {
         SymExpr::BoundVar {
-            id: self.id.clone(),
+            id: self.id,
             name: self.name.clone(),
             sort: self.sort.clone(),
         }
+    }
+
+    pub(crate) fn id(&self) -> BoundVarId {
+        self.id
     }
 
     pub fn name(&self) -> &str {
@@ -90,8 +96,8 @@ impl BoundVar {
 }
 
 impl BoundVarId {
-    pub(crate) fn depth(&self) -> usize {
-        self.depth
+    pub(crate) fn scope(&self) -> usize {
+        self.scope
     }
 
     pub(crate) fn index(&self) -> usize {
@@ -100,24 +106,19 @@ impl BoundVarId {
 }
 
 pub struct BoundVars {
-    scopes: Vec<Vec<(String, SymSort)>>,
+    scopes: Vec<Vec<BoundVar>>,
+    next_scope: Rc<Cell<usize>>,
 }
 
 impl BoundVars {
     pub fn get(&self, name: &str) -> SymExpr {
         self.scopes
             .iter()
-            .enumerate()
-            .find_map(|(depth, scope)| {
+            .find_map(|scope| {
                 scope
                     .iter()
-                    .enumerate()
-                    .find(|(_, (var_name, _))| var_name == name)
-                    .map(|(index, (name, sort))| SymExpr::BoundVar {
-                        id: BoundVarId { depth, index },
-                        name: name.clone(),
-                        sort: sort.clone(),
-                    })
+                    .find(|var| var.name() == name)
+                    .map(|var| var.expr())
             })
             .unwrap_or_else(|| panic!("unknown bound variable `{name}`"))
     }
@@ -127,7 +128,7 @@ impl BoundVars {
         vars: [(&str, SymSort); N],
         body: impl FnOnce(&BoundVars) -> SymExpr,
     ) -> SymExpr {
-        quantified_with_scopes(true, &self.scopes, vars, body)
+        quantified_with_scopes(true, &self.scopes, self.next_scope.clone(), vars, body)
     }
 
     pub fn exists<const N: usize>(
@@ -135,7 +136,7 @@ impl BoundVars {
         vars: [(&str, SymSort); N],
         body: impl FnOnce(&BoundVars) -> SymExpr,
     ) -> SymExpr {
-        quantified_with_scopes(false, &self.scopes, vars, body)
+        quantified_with_scopes(false, &self.scopes, self.next_scope.clone(), vars, body)
     }
 }
 
@@ -277,34 +278,34 @@ fn quantified<const N: usize>(
     vars: [(&str, SymSort); N],
     body: impl FnOnce(&BoundVars) -> SymExpr,
 ) -> SymExpr {
-    quantified_with_scopes(is_forall, &[], vars, body)
+    quantified_with_scopes(is_forall, &[], Rc::new(Cell::new(0)), vars, body)
 }
 
 fn quantified_with_scopes<const N: usize>(
     is_forall: bool,
-    outer_scopes: &[Vec<(String, SymSort)>],
+    outer_scopes: &[Vec<BoundVar>],
+    next_scope: Rc<Cell<usize>>,
     vars: [(&str, SymSort); N],
     body: impl FnOnce(&BoundVars) -> SymExpr,
 ) -> SymExpr {
+    let scope = next_scope.get();
+    next_scope.set(scope + 1);
+
     let vars = vars
         .into_iter()
         .enumerate()
         .map(|(index, (name, sort))| BoundVar {
-            id: BoundVarId { depth: 0, index },
+            id: BoundVarId { scope, index },
             name: name.to_string(),
             sort,
         })
         .collect::<Vec<_>>();
 
     let mut scopes = Vec::with_capacity(outer_scopes.len() + 1);
-    scopes.push(
-        vars.iter()
-            .map(|var| (var.name.clone(), var.sort.clone()))
-            .collect(),
-    );
+    scopes.push(vars.clone());
     scopes.extend_from_slice(outer_scopes);
 
-    let bound_vars = BoundVars { scopes };
+    let bound_vars = BoundVars { scopes, next_scope };
     let body = body(&bound_vars);
 
     if is_forall {

--- a/traceforge/src/symbolic/expr.rs
+++ b/traceforge/src/symbolic/expr.rs
@@ -1,8 +1,19 @@
+use crate::event::Event;
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, Div, Mul, Rem, Sub};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct SymVarId(pub u64);
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SymVarId(Event);
+
+impl SymVarId {
+    pub(crate) fn from_event(pos: Event) -> Self {
+        Self(pos)
+    }
+
+    pub(crate) fn suffix(&self) -> String {
+        format!("{}_{}", self.0.thread, self.0.index)
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SymSort {

--- a/traceforge/src/symbolic/expr.rs
+++ b/traceforge/src/symbolic/expr.rs
@@ -47,12 +47,112 @@ impl SymFunc {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BoundVarId {
+    depth: usize,
+    index: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BoundVar {
+    id: BoundVarId,
+    name: String,
+    sort: SymSort,
+}
+
+impl BoundVar {
+    pub fn expr(&self) -> SymExpr {
+        SymExpr::BoundVar {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            sort: self.sort.clone(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn sort(&self) -> &SymSort {
+        &self.sort
+    }
+}
+
+impl BoundVarId {
+    pub(crate) fn depth(&self) -> usize {
+        self.depth
+    }
+
+    pub(crate) fn index(&self) -> usize {
+        self.index
+    }
+}
+
+pub struct BoundVars {
+    scopes: Vec<Vec<(String, SymSort)>>,
+}
+
+impl BoundVars {
+    pub fn get(&self, name: &str) -> SymExpr {
+        self.scopes
+            .iter()
+            .enumerate()
+            .find_map(|(depth, scope)| {
+                scope
+                    .iter()
+                    .enumerate()
+                    .find(|(_, (var_name, _))| var_name == name)
+                    .map(|(index, (name, sort))| SymExpr::BoundVar {
+                        id: BoundVarId { depth, index },
+                        name: name.clone(),
+                        sort: sort.clone(),
+                    })
+            })
+            .unwrap_or_else(|| panic!("unknown bound variable `{name}`"))
+    }
+
+    pub fn forall<const N: usize>(
+        &self,
+        vars: [(&str, SymSort); N],
+        body: impl FnOnce(&BoundVars) -> SymExpr,
+    ) -> SymExpr {
+        quantified_with_scopes(true, &self.scopes, vars, body)
+    }
+
+    pub fn exists<const N: usize>(
+        &self,
+        vars: [(&str, SymSort); N],
+        body: impl FnOnce(&BoundVars) -> SymExpr,
+    ) -> SymExpr {
+        quantified_with_scopes(false, &self.scopes, vars, body)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SymExpr {
-    Var { id: SymVarId, sort: SymSort },
+    Var {
+        id: SymVarId,
+        sort: SymSort,
+    },
+    BoundVar {
+        id: BoundVarId,
+        name: String,
+        sort: SymSort,
+    },
     Bool(bool),
     Int(i64),
-    App { func: SymFunc, args: Vec<SymExpr> },
+    App {
+        func: SymFunc,
+        args: Vec<SymExpr>,
+    },
+    Forall {
+        vars: Vec<BoundVar>,
+        body: Box<SymExpr>,
+    },
+    Exists {
+        vars: Vec<BoundVar>,
+        body: Box<SymExpr>,
+    },
     Not(Box<SymExpr>),
     And(Box<SymExpr>, Box<SymExpr>),
     Or(Box<SymExpr>, Box<SymExpr>),
@@ -145,6 +245,68 @@ pub fn predicate(name: impl Into<String>, domain: &[SymSort]) -> SymFunc {
 
 pub fn constant(name: impl Into<String>, sort: SymSort) -> SymExpr {
     SymFunc::new(name, Vec::new(), sort).apply([])
+}
+
+pub fn forall<const N: usize>(
+    vars: [(&str, SymSort); N],
+    body: impl FnOnce(&BoundVars) -> SymExpr,
+) -> SymExpr {
+    quantified(true, vars, body)
+}
+
+pub fn exists<const N: usize>(
+    vars: [(&str, SymSort); N],
+    body: impl FnOnce(&BoundVars) -> SymExpr,
+) -> SymExpr {
+    quantified(false, vars, body)
+}
+
+fn quantified<const N: usize>(
+    is_forall: bool,
+    vars: [(&str, SymSort); N],
+    body: impl FnOnce(&BoundVars) -> SymExpr,
+) -> SymExpr {
+    quantified_with_scopes(is_forall, &[], vars, body)
+}
+
+fn quantified_with_scopes<const N: usize>(
+    is_forall: bool,
+    outer_scopes: &[Vec<(String, SymSort)>],
+    vars: [(&str, SymSort); N],
+    body: impl FnOnce(&BoundVars) -> SymExpr,
+) -> SymExpr {
+    let vars = vars
+        .into_iter()
+        .enumerate()
+        .map(|(index, (name, sort))| BoundVar {
+            id: BoundVarId { depth: 0, index },
+            name: name.to_string(),
+            sort,
+        })
+        .collect::<Vec<_>>();
+
+    let mut scopes = Vec::with_capacity(outer_scopes.len() + 1);
+    scopes.push(
+        vars.iter()
+            .map(|var| (var.name.clone(), var.sort.clone()))
+            .collect(),
+    );
+    scopes.extend_from_slice(outer_scopes);
+
+    let bound_vars = BoundVars { scopes };
+    let body = body(&bound_vars);
+
+    if is_forall {
+        SymExpr::Forall {
+            vars,
+            body: Box::new(body),
+        }
+    } else {
+        SymExpr::Exists {
+            vars,
+            body: Box::new(body),
+        }
+    }
 }
 
 impl From<i64> for SymExpr {

--- a/traceforge/src/symbolic/expr.rs
+++ b/traceforge/src/symbolic/expr.rs
@@ -4,10 +4,47 @@ use std::ops::{Add, Div, Mul, Rem, Sub};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SymVarId(pub u64);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SymSort {
     Bool,
     Int,
+    Uninterpreted(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SymFunc {
+    name: String,
+    domain: Vec<SymSort>,
+    range: SymSort,
+}
+
+impl SymFunc {
+    pub fn new(name: impl Into<String>, domain: Vec<SymSort>, range: SymSort) -> Self {
+        Self {
+            name: name.into(),
+            domain,
+            range,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn domain(&self) -> &[SymSort] {
+        &self.domain
+    }
+
+    pub fn range(&self) -> &SymSort {
+        &self.range
+    }
+
+    pub fn apply(&self, args: impl IntoIterator<Item = SymExpr>) -> SymExpr {
+        SymExpr::App {
+            func: self.clone(),
+            args: args.into_iter().collect(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -15,6 +52,7 @@ pub enum SymExpr {
     Var { id: SymVarId, sort: SymSort },
     Bool(bool),
     Int(i64),
+    App { func: SymFunc, args: Vec<SymExpr> },
     Not(Box<SymExpr>),
     And(Box<SymExpr>, Box<SymExpr>),
     Or(Box<SymExpr>, Box<SymExpr>),
@@ -91,6 +129,22 @@ pub fn int_val(v: i64) -> SymExpr {
 
 pub fn bool_val(v: bool) -> SymExpr {
     SymExpr::Bool(v)
+}
+
+pub fn uninterpreted_sort(name: impl Into<String>) -> SymSort {
+    SymSort::Uninterpreted(name.into())
+}
+
+pub fn uf(name: impl Into<String>, domain: &[SymSort], range: SymSort) -> SymFunc {
+    SymFunc::new(name, domain.to_vec(), range)
+}
+
+pub fn predicate(name: impl Into<String>, domain: &[SymSort]) -> SymFunc {
+    uf(name, domain, SymSort::Bool)
+}
+
+pub fn constant(name: impl Into<String>, sort: SymSort) -> SymExpr {
+    SymFunc::new(name, Vec::new(), sort).apply([])
 }
 
 impl From<i64> for SymExpr {

--- a/traceforge/src/symbolic/expr.rs
+++ b/traceforge/src/symbolic/expr.rs
@@ -48,7 +48,7 @@ impl SymExpr {
         SymExpr::Implies(Box::new(self), Box::new(other.into()))
     }
 
-    pub fn eq(self, other: impl Into<SymExpr>) -> Self {
+    pub fn equals(self, other: impl Into<SymExpr>) -> Self {
         SymExpr::Eq(Box::new(self), Box::new(other.into()))
     }
 
@@ -72,7 +72,7 @@ impl SymExpr {
         SymExpr::Sub(Box::new(self), Box::new(other.into()))
     }
 
-    pub fn mult(self, other: impl Into<SymExpr>) -> Self {
+    pub fn mul(self, other: impl Into<SymExpr>) -> Self {
         SymExpr::Mul(Box::new(self), Box::new(other.into()))
     }
 

--- a/traceforge/src/symbolic/mod.rs
+++ b/traceforge/src/symbolic/mod.rs
@@ -22,10 +22,10 @@ pub fn fresh_uninterpreted(name: impl Into<String>) -> SymExpr {
 pub fn fresh(sort: SymSort) -> SymExpr {
     ExecutionState::with(|s| {
         let pos = s.next_pos();
-        let id = s.must.borrow_mut().next_symbolic_var_id();
+        let id = SymVarId::from_event(pos);
         s.must
             .borrow_mut()
-            .handle_symbolic_var(SymbolicVar::new(pos, id, sort.clone()));
+            .handle_symbolic_var(SymbolicVar::new(pos, id.clone(), sort.clone()));
         SymExpr::Var { id, sort }
     })
 }

--- a/traceforge/src/symbolic/mod.rs
+++ b/traceforge/src/symbolic/mod.rs
@@ -4,7 +4,7 @@ mod solver;
 pub use expr::*;
 pub(crate) use solver::SymbolicSolver;
 
-use crate::event_label::{ConstraintEval, ConstraintKind, SymbolicVar};
+use crate::event_label::{ConstraintEval, SymbolicVar};
 use crate::runtime::execution::ExecutionState;
 
 pub fn fresh_int() -> SymExpr {
@@ -38,7 +38,7 @@ pub fn fresh_bool() -> SymExpr {
 pub fn eval(sym_expr: SymExpr) -> bool {
     ExecutionState::with(|s| {
         let pos = s.next_pos();
-        let lab = ConstraintEval::new(pos, sym_expr, ConstraintKind::Branch, true);
+        let lab = ConstraintEval::new(pos, sym_expr, true);
         s.must.borrow_mut().handle_constraint_eval(lab)
     })
 }

--- a/traceforge/src/symbolic/mod.rs
+++ b/traceforge/src/symbolic/mod.rs
@@ -8,30 +8,25 @@ use crate::event_label::{ConstraintEval, SymbolicVar};
 use crate::runtime::execution::ExecutionState;
 
 pub fn fresh_int() -> SymExpr {
-    ExecutionState::with(|s| {
-        let pos = s.next_pos();
-        let id = s.must.borrow_mut().next_symbolic_var_id();
-        s.must
-            .borrow_mut()
-            .handle_symbolic_var(SymbolicVar::new(pos, id, SymSort::Int));
-        SymExpr::Var {
-            id,
-            sort: SymSort::Int,
-        }
-    })
+    fresh(SymSort::Int)
 }
 
 pub fn fresh_bool() -> SymExpr {
+    fresh(SymSort::Bool)
+}
+
+pub fn fresh_uninterpreted(name: impl Into<String>) -> SymExpr {
+    fresh(SymSort::Uninterpreted(name.into()))
+}
+
+pub fn fresh(sort: SymSort) -> SymExpr {
     ExecutionState::with(|s| {
         let pos = s.next_pos();
         let id = s.must.borrow_mut().next_symbolic_var_id();
         s.must
             .borrow_mut()
-            .handle_symbolic_var(SymbolicVar::new(pos, id, SymSort::Bool));
-        SymExpr::Var {
-            id,
-            sort: SymSort::Bool,
-        }
+            .handle_symbolic_var(SymbolicVar::new(pos, id, sort.clone()));
+        SymExpr::Var { id, sort }
     })
 }
 

--- a/traceforge/src/symbolic/mod.rs
+++ b/traceforge/src/symbolic/mod.rs
@@ -1,0 +1,54 @@
+mod expr;
+mod solver;
+
+pub use expr::*;
+pub(crate) use solver::SymbolicSolver;
+
+use crate::event_label::{ConstraintEval, ConstraintKind, SymbolicVar};
+use crate::runtime::execution::ExecutionState;
+
+pub fn fresh_int() -> SymExpr {
+    ExecutionState::with(|s| {
+        let pos = s.next_pos();
+        let id = s.must.borrow_mut().next_symbolic_var_id();
+        s.must
+            .borrow_mut()
+            .handle_symbolic_var(SymbolicVar::new(pos, id, SymSort::Int));
+        SymExpr::Var {
+            id,
+            sort: SymSort::Int,
+        }
+    })
+}
+
+pub fn fresh_bool() -> SymExpr {
+    ExecutionState::with(|s| {
+        let pos = s.next_pos();
+        let id = s.must.borrow_mut().next_symbolic_var_id();
+        s.must
+            .borrow_mut()
+            .handle_symbolic_var(SymbolicVar::new(pos, id, SymSort::Bool));
+        SymExpr::Var {
+            id,
+            sort: SymSort::Bool,
+        }
+    })
+}
+
+pub fn eval(sym_expr: SymExpr) -> bool {
+    ExecutionState::with(|s| {
+        let pos = s.next_pos();
+        let lab = ConstraintEval::new(pos, sym_expr, ConstraintKind::Branch, true);
+        s.must.borrow_mut().handle_constraint_eval(lab)
+    })
+}
+
+pub fn assume(sym_expr: SymExpr) {
+    let ok = eval(sym_expr);
+    crate::assume_impl(ok, None);
+}
+
+pub fn assert(sym_expr: SymExpr) {
+    let ok = eval(sym_expr);
+    crate::assert(ok);
+}

--- a/traceforge/src/symbolic/solver.rs
+++ b/traceforge/src/symbolic/solver.rs
@@ -76,17 +76,17 @@ impl SymbolicSolver {
             SymExpr::Var {
                 id,
                 sort: SymSort::Bool,
-            } => Dynamic::from_ast(&Bool::new_const(format!("sym_b_{}", id.0))),
+            } => Dynamic::from_ast(&Bool::new_const(format!("sym_b_{}", id.suffix()))),
             SymExpr::Var {
                 id,
                 sort: SymSort::Int,
-            } => Dynamic::from_ast(&Int::new_const(format!("sym_i_{}", id.0))),
+            } => Dynamic::from_ast(&Int::new_const(format!("sym_i_{}", id.suffix()))),
             SymExpr::Var {
                 id,
                 sort: sort @ SymSort::Uninterpreted(_),
             } => {
                 let sort = self.compile_sort(sort);
-                Dynamic::new_const(format!("sym_u_{}", id.0), &sort)
+                Dynamic::new_const(format!("sym_u_{}", id.suffix()), &sort)
             }
             SymExpr::BoundVar { id, .. } => self.lookup_bound(env, id),
             SymExpr::Bool(value) => Dynamic::from_ast(&Bool::from_bool(*value)),

--- a/traceforge/src/symbolic/solver.rs
+++ b/traceforge/src/symbolic/solver.rs
@@ -1,5 +1,6 @@
-use crate::symbolic::{SymExpr, SymSort};
-use z3::ast::{Bool, Int};
+use crate::symbolic::{SymExpr, SymFunc, SymSort};
+use z3::ast::{Ast, Bool, Dynamic, Int};
+use z3::{FuncDecl, Sort, Symbol};
 
 pub(crate) struct SymbolicSolver {
     solver: z3::Solver,
@@ -49,67 +50,101 @@ impl SymbolicSolver {
     }
 
     fn compile_bool(&self, expr: &SymExpr) -> Bool {
+        self.compile_dynamic(expr)
+            .as_bool()
+            .unwrap_or_else(|| panic!("expected symbolic bool expression, got {:?}", expr))
+    }
+
+    fn compile_int(&self, expr: &SymExpr) -> Int {
+        self.compile_dynamic(expr)
+            .as_int()
+            .unwrap_or_else(|| panic!("expected symbolic int expression, got {:?}", expr))
+    }
+
+    fn compile_dynamic(&self, expr: &SymExpr) -> Dynamic {
         match expr {
             SymExpr::Var {
                 id,
                 sort: SymSort::Bool,
-            } => Bool::new_const(format!("sym_b_{}", id.0)),
-            SymExpr::Bool(value) => Bool::from_bool(*value),
-            SymExpr::Not(inner) => self.compile_bool(inner).not(),
+            } => Dynamic::from_ast(&Bool::new_const(format!("sym_b_{}", id.0))),
+            SymExpr::Var {
+                id,
+                sort: SymSort::Int,
+            } => Dynamic::from_ast(&Int::new_const(format!("sym_i_{}", id.0))),
+            SymExpr::Var {
+                id,
+                sort: sort @ SymSort::Uninterpreted(_),
+            } => {
+                let sort = self.compile_sort(sort);
+                Dynamic::new_const(format!("sym_u_{}", id.0), &sort)
+            }
+            SymExpr::Bool(value) => Dynamic::from_ast(&Bool::from_bool(*value)),
+            SymExpr::Int(value) => Dynamic::from_ast(&Int::from_i64(*value)),
+            SymExpr::App { func, args } => self.compile_app(func, args),
+            SymExpr::Not(inner) => Dynamic::from_ast(&self.compile_bool(inner).not()),
             SymExpr::And(lhs, rhs) => {
                 let lhs = self.compile_bool(lhs);
                 let rhs = self.compile_bool(rhs);
-                Bool::and(&[lhs, rhs])
+                Dynamic::from_ast(&Bool::and(&[lhs, rhs]))
             }
             SymExpr::Or(lhs, rhs) => {
                 let lhs = self.compile_bool(lhs);
                 let rhs = self.compile_bool(rhs);
-                Bool::or(&[lhs, rhs])
+                Dynamic::from_ast(&Bool::or(&[lhs, rhs]))
             }
-            SymExpr::Implies(lhs, rhs) => self.compile_bool(lhs).implies(self.compile_bool(rhs)),
-            SymExpr::Eq(lhs, rhs) => match self.expr_sort(lhs) {
-                SymSort::Bool => self.compile_bool(lhs).eq(self.compile_bool(rhs)),
-                SymSort::Int => self.compile_int(lhs).eq(self.compile_int(rhs)),
-            },
-            SymExpr::Gt(lhs, rhs) => self.compile_int(lhs).gt(self.compile_int(rhs)),
-            SymExpr::Ge(lhs, rhs) => self.compile_int(lhs).ge(self.compile_int(rhs)),
-            SymExpr::Lt(lhs, rhs) => self.compile_int(lhs).lt(self.compile_int(rhs)),
-            SymExpr::Le(lhs, rhs) => self.compile_int(lhs).le(self.compile_int(rhs)),
-            other => panic!("expected symbolic bool expression, got {:?}", other),
-        }
-    }
-
-    fn compile_int(&self, expr: &SymExpr) -> Int {
-        match expr {
-            SymExpr::Var {
-                id,
-                sort: SymSort::Int,
-            } => Int::new_const(format!("sym_i_{}", id.0)),
-            SymExpr::Int(value) => Int::from_i64(*value),
+            SymExpr::Implies(lhs, rhs) => {
+                Dynamic::from_ast(&self.compile_bool(lhs).implies(self.compile_bool(rhs)))
+            }
+            SymExpr::Eq(lhs, rhs) => {
+                self.expect_same_sort(lhs, rhs, "equality");
+                let lhs = self.compile_dynamic(lhs);
+                let rhs = self.compile_dynamic(rhs);
+                Dynamic::from_ast(&lhs.eq(&rhs))
+            }
+            SymExpr::Gt(lhs, rhs) => {
+                Dynamic::from_ast(&self.compile_int(lhs).gt(self.compile_int(rhs)))
+            }
+            SymExpr::Ge(lhs, rhs) => {
+                Dynamic::from_ast(&self.compile_int(lhs).ge(self.compile_int(rhs)))
+            }
+            SymExpr::Lt(lhs, rhs) => {
+                Dynamic::from_ast(&self.compile_int(lhs).lt(self.compile_int(rhs)))
+            }
+            SymExpr::Le(lhs, rhs) => {
+                Dynamic::from_ast(&self.compile_int(lhs).le(self.compile_int(rhs)))
+            }
             SymExpr::Add(lhs, rhs) => {
+                self.expect_int_operands(lhs, rhs, "addition");
                 let lhs = self.compile_int(lhs);
                 let rhs = self.compile_int(rhs);
-                Int::add(&[lhs, rhs])
+                Dynamic::from_ast(&Int::add(&[lhs, rhs]))
             }
             SymExpr::Sub(lhs, rhs) => {
+                self.expect_int_operands(lhs, rhs, "subtraction");
                 let lhs = self.compile_int(lhs);
                 let rhs = self.compile_int(rhs);
-                Int::sub(&[lhs, rhs])
+                Dynamic::from_ast(&Int::sub(&[lhs, rhs]))
             }
             SymExpr::Mul(lhs, rhs) => {
+                self.expect_int_operands(lhs, rhs, "multiplication");
                 let lhs = self.compile_int(lhs);
                 let rhs = self.compile_int(rhs);
-                Int::mul(&[lhs, rhs])
+                Dynamic::from_ast(&Int::mul(&[lhs, rhs]))
             }
-            SymExpr::Div(lhs, rhs) => self.compile_int(lhs).div(self.compile_int(rhs)),
-            SymExpr::Rem(lhs, rhs) => self.compile_int(lhs).rem(self.compile_int(rhs)),
-            other => panic!("expected symbolic int expression, got {:?}", other),
+            SymExpr::Div(lhs, rhs) => {
+                self.expect_int_operands(lhs, rhs, "division");
+                Dynamic::from_ast(&self.compile_int(lhs).div(self.compile_int(rhs)))
+            }
+            SymExpr::Rem(lhs, rhs) => {
+                self.expect_int_operands(lhs, rhs, "remainder");
+                Dynamic::from_ast(&self.compile_int(lhs).rem(self.compile_int(rhs)))
+            }
         }
     }
 
     fn expr_sort(&self, expr: &SymExpr) -> SymSort {
         match expr {
-            SymExpr::Var { sort, .. } => *sort,
+            SymExpr::Var { sort, .. } => sort.clone(),
             SymExpr::Bool(_)
             | SymExpr::Not(_)
             | SymExpr::And(_, _)
@@ -126,6 +161,89 @@ impl SymbolicSolver {
             | SymExpr::Mul(_, _)
             | SymExpr::Div(_, _)
             | SymExpr::Rem(_, _) => SymSort::Int,
+            SymExpr::App { func, args } => {
+                self.validate_app(func, args);
+                func.range().clone()
+            }
+        }
+    }
+
+    fn compile_sort(&self, sort: &SymSort) -> Sort {
+        match sort {
+            SymSort::Bool => Sort::bool(),
+            SymSort::Int => Sort::int(),
+            SymSort::Uninterpreted(name) => Sort::uninterpreted(Symbol::String(name.clone())),
+        }
+    }
+
+    fn compile_func(&self, func: &SymFunc) -> FuncDecl {
+        let domain = func
+            .domain()
+            .iter()
+            .map(|sort| self.compile_sort(sort))
+            .collect::<Vec<_>>();
+        let domain_refs = domain.iter().collect::<Vec<_>>();
+        let range = self.compile_sort(func.range());
+
+        FuncDecl::new(func.name(), &domain_refs, &range)
+    }
+
+    fn compile_app(&self, func: &SymFunc, args: &[SymExpr]) -> Dynamic {
+        self.validate_app(func, args);
+
+        let decl = self.compile_func(func);
+        let args = args
+            .iter()
+            .map(|arg| self.compile_dynamic(arg))
+            .collect::<Vec<_>>();
+        let arg_refs = args.iter().map(|arg| arg as &dyn Ast).collect::<Vec<_>>();
+
+        decl.apply(&arg_refs)
+    }
+
+    fn validate_app(&self, func: &SymFunc, args: &[SymExpr]) {
+        if func.domain().len() != args.len() {
+            panic!(
+                "uninterpreted function `{}` expects {} arguments, got {}",
+                func.name(),
+                func.domain().len(),
+                args.len()
+            );
+        }
+
+        for (index, (expected, actual)) in func.domain().iter().zip(args).enumerate() {
+            let actual = self.expr_sort(actual);
+            if expected != &actual {
+                panic!(
+                    "uninterpreted function `{}` argument {} expected sort {:?}, got {:?}",
+                    func.name(),
+                    index,
+                    expected,
+                    actual
+                );
+            }
+        }
+    }
+
+    fn expect_same_sort(&self, lhs: &SymExpr, rhs: &SymExpr, op: &str) {
+        let lhs_sort = self.expr_sort(lhs);
+        let rhs_sort = self.expr_sort(rhs);
+        if lhs_sort != rhs_sort {
+            panic!(
+                "{} expected matching sorts, got {:?} and {:?}",
+                op, lhs_sort, rhs_sort
+            );
+        }
+    }
+
+    fn expect_int_operands(&self, lhs: &SymExpr, rhs: &SymExpr, op: &str) {
+        let lhs_sort = self.expr_sort(lhs);
+        let rhs_sort = self.expr_sort(rhs);
+        if lhs_sort != SymSort::Int || rhs_sort != SymSort::Int {
+            panic!(
+                "{} expected Int operands, got {:?} and {:?}",
+                op, lhs_sort, rhs_sort
+            );
         }
     }
 }

--- a/traceforge/src/symbolic/solver.rs
+++ b/traceforge/src/symbolic/solver.rs
@@ -1,8 +1,9 @@
 use crate::symbolic::{BoundVar, BoundVarId, SymExpr, SymFunc, SymSort};
+use std::collections::HashMap;
 use z3::ast::{Ast, Bool, Dynamic, Int};
 use z3::{FuncDecl, Sort, Symbol};
 
-type BoundEnv = Vec<Vec<Dynamic>>;
+type BoundEnv = HashMap<BoundVarId, Dynamic>;
 
 pub(crate) struct SymbolicSolver {
     solver: z3::Solver,
@@ -56,7 +57,7 @@ impl SymbolicSolver {
     }
 
     fn compile_bool(&self, expr: &SymExpr) -> Bool {
-        self.compile_bool_with_env(expr, &mut Vec::new())
+        self.compile_bool_with_env(expr, &mut HashMap::new())
     }
 
     fn compile_bool_with_env(&self, expr: &SymExpr, env: &mut BoundEnv) -> Bool {
@@ -246,15 +247,22 @@ impl SymbolicSolver {
             .iter()
             .map(|var| {
                 let sort = self.compile_sort(var.sort());
-                Dynamic::new_const(format!("q_{}_{}", var.name(), env.len()), &sort)
+                Dynamic::new_const(
+                    format!("q_{}_{}_{}", var.name(), var.id().scope(), var.id().index()),
+                    &sort,
+                )
             })
             .collect::<Vec<_>>();
 
-        env.push(z3_vars.clone());
+        for (var, z3_var) in vars.iter().zip(z3_vars.iter()) {
+            env.insert(var.id(), z3_var.clone());
+        }
 
         let body = self.compile_bool_with_env(body, env);
 
-        env.pop();
+        for var in vars {
+            env.remove(&var.id());
+        }
 
         let var_refs = z3_vars
             .iter()
@@ -269,12 +277,7 @@ impl SymbolicSolver {
     }
 
     fn lookup_bound(&self, env: &BoundEnv, id: &BoundVarId) -> Dynamic {
-        let scope_index = env
-            .len()
-            .checked_sub(1 + id.depth())
-            .unwrap_or_else(|| panic!("unbound quantified variable {:?}", id));
-        env.get(scope_index)
-            .and_then(|scope| scope.get(id.index()))
+        env.get(id)
             .cloned()
             .unwrap_or_else(|| panic!("unbound quantified variable {:?}", id))
     }

--- a/traceforge/src/symbolic/solver.rs
+++ b/traceforge/src/symbolic/solver.rs
@@ -1,6 +1,8 @@
-use crate::symbolic::{SymExpr, SymFunc, SymSort};
+use crate::symbolic::{BoundVar, BoundVarId, SymExpr, SymFunc, SymSort};
 use z3::ast::{Ast, Bool, Dynamic, Int};
 use z3::{FuncDecl, Sort, Symbol};
+
+type BoundEnv = Vec<Vec<Dynamic>>;
 
 pub(crate) struct SymbolicSolver {
     solver: z3::Solver,
@@ -46,22 +48,30 @@ impl SymbolicSolver {
     }
 
     pub(crate) fn is_sat(&self) -> bool {
-        self.solver.check() == z3::SatResult::Sat
+        match self.solver.check() {
+            z3::SatResult::Sat => true,
+            z3::SatResult::Unsat => false,
+            z3::SatResult::Unknown => panic!("Z3 returned unknown for symbolic constraint"),
+        }
     }
 
     fn compile_bool(&self, expr: &SymExpr) -> Bool {
-        self.compile_dynamic(expr)
+        self.compile_bool_with_env(expr, &mut Vec::new())
+    }
+
+    fn compile_bool_with_env(&self, expr: &SymExpr, env: &mut BoundEnv) -> Bool {
+        self.compile_dynamic(expr, env)
             .as_bool()
             .unwrap_or_else(|| panic!("expected symbolic bool expression, got {:?}", expr))
     }
 
-    fn compile_int(&self, expr: &SymExpr) -> Int {
-        self.compile_dynamic(expr)
+    fn compile_int_with_env(&self, expr: &SymExpr, env: &mut BoundEnv) -> Int {
+        self.compile_dynamic(expr, env)
             .as_int()
             .unwrap_or_else(|| panic!("expected symbolic int expression, got {:?}", expr))
     }
 
-    fn compile_dynamic(&self, expr: &SymExpr) -> Dynamic {
+    fn compile_dynamic(&self, expr: &SymExpr, env: &mut BoundEnv) -> Dynamic {
         match expr {
             SymExpr::Var {
                 id,
@@ -78,78 +88,97 @@ impl SymbolicSolver {
                 let sort = self.compile_sort(sort);
                 Dynamic::new_const(format!("sym_u_{}", id.0), &sort)
             }
+            SymExpr::BoundVar { id, .. } => self.lookup_bound(env, id),
             SymExpr::Bool(value) => Dynamic::from_ast(&Bool::from_bool(*value)),
             SymExpr::Int(value) => Dynamic::from_ast(&Int::from_i64(*value)),
-            SymExpr::App { func, args } => self.compile_app(func, args),
-            SymExpr::Not(inner) => Dynamic::from_ast(&self.compile_bool(inner).not()),
+            SymExpr::App { func, args } => self.compile_app(func, args, env),
+            SymExpr::Forall { vars, body } => self.compile_quantifier(true, vars, body, env),
+            SymExpr::Exists { vars, body } => self.compile_quantifier(false, vars, body, env),
+            SymExpr::Not(inner) => Dynamic::from_ast(&self.compile_bool_with_env(inner, env).not()),
             SymExpr::And(lhs, rhs) => {
-                let lhs = self.compile_bool(lhs);
-                let rhs = self.compile_bool(rhs);
+                let lhs = self.compile_bool_with_env(lhs, env);
+                let rhs = self.compile_bool_with_env(rhs, env);
                 Dynamic::from_ast(&Bool::and(&[lhs, rhs]))
             }
             SymExpr::Or(lhs, rhs) => {
-                let lhs = self.compile_bool(lhs);
-                let rhs = self.compile_bool(rhs);
+                let lhs = self.compile_bool_with_env(lhs, env);
+                let rhs = self.compile_bool_with_env(rhs, env);
                 Dynamic::from_ast(&Bool::or(&[lhs, rhs]))
             }
             SymExpr::Implies(lhs, rhs) => {
-                Dynamic::from_ast(&self.compile_bool(lhs).implies(self.compile_bool(rhs)))
+                let lhs = self.compile_bool_with_env(lhs, env);
+                let rhs = self.compile_bool_with_env(rhs, env);
+                Dynamic::from_ast(&lhs.implies(rhs))
             }
             SymExpr::Eq(lhs, rhs) => {
                 self.expect_same_sort(lhs, rhs, "equality");
-                let lhs = self.compile_dynamic(lhs);
-                let rhs = self.compile_dynamic(rhs);
+                let lhs = self.compile_dynamic(lhs, env);
+                let rhs = self.compile_dynamic(rhs, env);
                 Dynamic::from_ast(&lhs.eq(&rhs))
             }
             SymExpr::Gt(lhs, rhs) => {
-                Dynamic::from_ast(&self.compile_int(lhs).gt(self.compile_int(rhs)))
+                let lhs = self.compile_int_with_env(lhs, env);
+                let rhs = self.compile_int_with_env(rhs, env);
+                Dynamic::from_ast(&lhs.gt(rhs))
             }
             SymExpr::Ge(lhs, rhs) => {
-                Dynamic::from_ast(&self.compile_int(lhs).ge(self.compile_int(rhs)))
+                let lhs = self.compile_int_with_env(lhs, env);
+                let rhs = self.compile_int_with_env(rhs, env);
+                Dynamic::from_ast(&lhs.ge(rhs))
             }
             SymExpr::Lt(lhs, rhs) => {
-                Dynamic::from_ast(&self.compile_int(lhs).lt(self.compile_int(rhs)))
+                let lhs = self.compile_int_with_env(lhs, env);
+                let rhs = self.compile_int_with_env(rhs, env);
+                Dynamic::from_ast(&lhs.lt(rhs))
             }
             SymExpr::Le(lhs, rhs) => {
-                Dynamic::from_ast(&self.compile_int(lhs).le(self.compile_int(rhs)))
+                let lhs = self.compile_int_with_env(lhs, env);
+                let rhs = self.compile_int_with_env(rhs, env);
+                Dynamic::from_ast(&lhs.le(rhs))
             }
             SymExpr::Add(lhs, rhs) => {
                 self.expect_int_operands(lhs, rhs, "addition");
-                let lhs = self.compile_int(lhs);
-                let rhs = self.compile_int(rhs);
+                let lhs = self.compile_int_with_env(lhs, env);
+                let rhs = self.compile_int_with_env(rhs, env);
                 Dynamic::from_ast(&Int::add(&[lhs, rhs]))
             }
             SymExpr::Sub(lhs, rhs) => {
                 self.expect_int_operands(lhs, rhs, "subtraction");
-                let lhs = self.compile_int(lhs);
-                let rhs = self.compile_int(rhs);
+                let lhs = self.compile_int_with_env(lhs, env);
+                let rhs = self.compile_int_with_env(rhs, env);
                 Dynamic::from_ast(&Int::sub(&[lhs, rhs]))
             }
             SymExpr::Mul(lhs, rhs) => {
                 self.expect_int_operands(lhs, rhs, "multiplication");
-                let lhs = self.compile_int(lhs);
-                let rhs = self.compile_int(rhs);
+                let lhs = self.compile_int_with_env(lhs, env);
+                let rhs = self.compile_int_with_env(rhs, env);
                 Dynamic::from_ast(&Int::mul(&[lhs, rhs]))
             }
             SymExpr::Div(lhs, rhs) => {
                 self.expect_int_operands(lhs, rhs, "division");
-                Dynamic::from_ast(&self.compile_int(lhs).div(self.compile_int(rhs)))
+                let lhs = self.compile_int_with_env(lhs, env);
+                let rhs = self.compile_int_with_env(rhs, env);
+                Dynamic::from_ast(&lhs.div(rhs))
             }
             SymExpr::Rem(lhs, rhs) => {
                 self.expect_int_operands(lhs, rhs, "remainder");
-                Dynamic::from_ast(&self.compile_int(lhs).rem(self.compile_int(rhs)))
+                let lhs = self.compile_int_with_env(lhs, env);
+                let rhs = self.compile_int_with_env(rhs, env);
+                Dynamic::from_ast(&lhs.rem(rhs))
             }
         }
     }
 
     fn expr_sort(&self, expr: &SymExpr) -> SymSort {
         match expr {
-            SymExpr::Var { sort, .. } => sort.clone(),
+            SymExpr::Var { sort, .. } | SymExpr::BoundVar { sort, .. } => sort.clone(),
             SymExpr::Bool(_)
             | SymExpr::Not(_)
             | SymExpr::And(_, _)
             | SymExpr::Or(_, _)
             | SymExpr::Implies(_, _)
+            | SymExpr::Forall { .. }
+            | SymExpr::Exists { .. }
             | SymExpr::Eq(_, _)
             | SymExpr::Gt(_, _)
             | SymExpr::Ge(_, _)
@@ -188,17 +217,66 @@ impl SymbolicSolver {
         FuncDecl::new(func.name(), &domain_refs, &range)
     }
 
-    fn compile_app(&self, func: &SymFunc, args: &[SymExpr]) -> Dynamic {
+    fn compile_app(&self, func: &SymFunc, args: &[SymExpr], env: &mut BoundEnv) -> Dynamic {
         self.validate_app(func, args);
 
         let decl = self.compile_func(func);
         let args = args
             .iter()
-            .map(|arg| self.compile_dynamic(arg))
+            .map(|arg| self.compile_dynamic(arg, env))
             .collect::<Vec<_>>();
         let arg_refs = args.iter().map(|arg| arg as &dyn Ast).collect::<Vec<_>>();
 
         decl.apply(&arg_refs)
+    }
+
+    fn compile_quantifier(
+        &self,
+        is_forall: bool,
+        vars: &[BoundVar],
+        body: &SymExpr,
+        env: &mut BoundEnv,
+    ) -> Dynamic {
+        let body_sort = self.expr_sort(body);
+        if body_sort != SymSort::Bool {
+            panic!("quantifier body must be Bool, got {:?}", body_sort);
+        }
+
+        let z3_vars = vars
+            .iter()
+            .map(|var| {
+                let sort = self.compile_sort(var.sort());
+                Dynamic::new_const(format!("q_{}_{}", var.name(), env.len()), &sort)
+            })
+            .collect::<Vec<_>>();
+
+        env.push(z3_vars.clone());
+
+        let body = self.compile_bool_with_env(body, env);
+
+        env.pop();
+
+        let var_refs = z3_vars
+            .iter()
+            .map(|var| var as &dyn Ast)
+            .collect::<Vec<_>>();
+
+        if is_forall {
+            Dynamic::from_ast(&z3::ast::forall_const(&var_refs, &[], &body))
+        } else {
+            Dynamic::from_ast(&z3::ast::exists_const(&var_refs, &[], &body))
+        }
+    }
+
+    fn lookup_bound(&self, env: &BoundEnv, id: &BoundVarId) -> Dynamic {
+        let scope_index = env
+            .len()
+            .checked_sub(1 + id.depth())
+            .unwrap_or_else(|| panic!("unbound quantified variable {:?}", id));
+        env.get(scope_index)
+            .and_then(|scope| scope.get(id.index()))
+            .cloned()
+            .unwrap_or_else(|| panic!("unbound quantified variable {:?}", id))
     }
 
     fn validate_app(&self, func: &SymFunc, args: &[SymExpr]) {

--- a/traceforge/src/symbolic/solver.rs
+++ b/traceforge/src/symbolic/solver.rs
@@ -1,0 +1,131 @@
+use crate::symbolic::{SymExpr, SymSort};
+use z3::ast::{Bool, Int};
+
+pub(crate) struct SymbolicSolver {
+    solver: z3::Solver,
+}
+
+impl SymbolicSolver {
+    pub(crate) fn new() -> Self {
+        Self {
+            solver: z3::Solver::new(),
+        }
+    }
+
+    pub(crate) fn assert(&mut self, expr: &SymExpr) {
+        let b = self.compile_bool(expr);
+        self.solver.assert(&b);
+    }
+
+    pub(crate) fn assert_not(&mut self, expr: &SymExpr) {
+        let b = self.compile_bool(expr);
+        self.solver.assert(&b.not());
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.solver.reset();
+    }
+
+    pub(crate) fn sat_with(&self, expr: &SymExpr) -> bool {
+        let b = self.compile_bool(expr);
+        self.solver.push();
+        self.solver.assert(&b);
+        let is_sat = self.is_sat();
+        self.solver.pop(1);
+        is_sat
+    }
+
+    pub(crate) fn sat_with_not(&self, expr: &SymExpr) -> bool {
+        let b = self.compile_bool(expr);
+        self.solver.push();
+        self.solver.assert(&b.not());
+        let is_sat = self.is_sat();
+        self.solver.pop(1);
+        is_sat
+    }
+
+    pub(crate) fn is_sat(&self) -> bool {
+        self.solver.check() == z3::SatResult::Sat
+    }
+
+    fn compile_bool(&self, expr: &SymExpr) -> Bool {
+        match expr {
+            SymExpr::Var {
+                id,
+                sort: SymSort::Bool,
+            } => Bool::new_const(format!("sym_b_{}", id.0)),
+            SymExpr::Bool(value) => Bool::from_bool(*value),
+            SymExpr::Not(inner) => self.compile_bool(inner).not(),
+            SymExpr::And(lhs, rhs) => {
+                let lhs = self.compile_bool(lhs);
+                let rhs = self.compile_bool(rhs);
+                Bool::and(&[lhs, rhs])
+            }
+            SymExpr::Or(lhs, rhs) => {
+                let lhs = self.compile_bool(lhs);
+                let rhs = self.compile_bool(rhs);
+                Bool::or(&[lhs, rhs])
+            }
+            SymExpr::Implies(lhs, rhs) => self.compile_bool(lhs).implies(self.compile_bool(rhs)),
+            SymExpr::Eq(lhs, rhs) => match self.expr_sort(lhs) {
+                SymSort::Bool => self.compile_bool(lhs).eq(self.compile_bool(rhs)),
+                SymSort::Int => self.compile_int(lhs).eq(self.compile_int(rhs)),
+            },
+            SymExpr::Gt(lhs, rhs) => self.compile_int(lhs).gt(self.compile_int(rhs)),
+            SymExpr::Ge(lhs, rhs) => self.compile_int(lhs).ge(self.compile_int(rhs)),
+            SymExpr::Lt(lhs, rhs) => self.compile_int(lhs).lt(self.compile_int(rhs)),
+            SymExpr::Le(lhs, rhs) => self.compile_int(lhs).le(self.compile_int(rhs)),
+            other => panic!("expected symbolic bool expression, got {:?}", other),
+        }
+    }
+
+    fn compile_int(&self, expr: &SymExpr) -> Int {
+        match expr {
+            SymExpr::Var {
+                id,
+                sort: SymSort::Int,
+            } => Int::new_const(format!("sym_i_{}", id.0)),
+            SymExpr::Int(value) => Int::from_i64(*value),
+            SymExpr::Add(lhs, rhs) => {
+                let lhs = self.compile_int(lhs);
+                let rhs = self.compile_int(rhs);
+                Int::add(&[lhs, rhs])
+            }
+            SymExpr::Sub(lhs, rhs) => {
+                let lhs = self.compile_int(lhs);
+                let rhs = self.compile_int(rhs);
+                Int::sub(&[lhs, rhs])
+            }
+            SymExpr::Mul(lhs, rhs) => {
+                let lhs = self.compile_int(lhs);
+                let rhs = self.compile_int(rhs);
+                Int::mul(&[lhs, rhs])
+            }
+            SymExpr::Div(lhs, rhs) => self.compile_int(lhs).div(self.compile_int(rhs)),
+            SymExpr::Rem(lhs, rhs) => self.compile_int(lhs).rem(self.compile_int(rhs)),
+            other => panic!("expected symbolic int expression, got {:?}", other),
+        }
+    }
+
+    fn expr_sort(&self, expr: &SymExpr) -> SymSort {
+        match expr {
+            SymExpr::Var { sort, .. } => *sort,
+            SymExpr::Bool(_)
+            | SymExpr::Not(_)
+            | SymExpr::And(_, _)
+            | SymExpr::Or(_, _)
+            | SymExpr::Implies(_, _)
+            | SymExpr::Eq(_, _)
+            | SymExpr::Gt(_, _)
+            | SymExpr::Ge(_, _)
+            | SymExpr::Lt(_, _)
+            | SymExpr::Le(_, _) => SymSort::Bool,
+            SymExpr::Int(_)
+            | SymExpr::Add(_, _)
+            | SymExpr::Sub(_, _)
+            | SymExpr::Mul(_, _)
+            | SymExpr::Div(_, _)
+            | SymExpr::Rem(_, _) => SymSort::Int,
+        }
+    }
+}

--- a/traceforge/tests/symbolic.rs
+++ b/traceforge/tests/symbolic.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use traceforge::{
     recv_msg, recv_msg_block, send_msg, symbolic, thread, verify, Config, SchedulePolicy,
 };
@@ -376,4 +378,52 @@ fn symbolic_backward_revisit_with_uninterpreted_predicate_is_optimal() {
     });
 
     assert_eq!((stats.execs, stats.block), (3, 0));
+}
+
+#[test]
+fn symbolic_var_ids_are_stable_across_different_schedule_orders() {
+    let observations = Arc::new(Mutex::new(Vec::new()));
+    let observations_clone = observations.clone();
+
+    traceforge::test(
+        Config::builder()
+            .with_policy(SchedulePolicy::Arbitrary)
+            .with_symbolic(true)
+            .build(),
+        move || {
+            let observations_ref = observations_clone.clone();
+            let main_id = thread::current_id();
+
+            let left = thread::spawn(move || {
+                let x = symbolic::fresh_int();
+                send_msg(main_id, ("left".to_string(), format!("{x:?}")));
+            });
+
+            let main_id = thread::current_id();
+            let right = thread::spawn(move || {
+                let y = symbolic::fresh_int();
+                send_msg(main_id, ("right".to_string(), format!("{y:?}")));
+            });
+
+            let first: (String, String) = recv_msg_block();
+            let second: (String, String) = recv_msg_block();
+            observations_ref.lock().unwrap().extend([first, second]);
+
+            left.join().unwrap();
+            right.join().unwrap();
+        },
+        20,
+    );
+
+    let mut ids_by_role = HashMap::<String, HashSet<String>>::new();
+    for (role, expr) in observations.lock().unwrap().iter() {
+        ids_by_role
+            .entry(role.clone())
+            .or_default()
+            .insert(expr.clone());
+    }
+
+    assert_eq!(ids_by_role["left"].len(), 1, "{ids_by_role:#?}");
+    assert_eq!(ids_by_role["right"].len(), 1, "{ids_by_role:#?}");
+    assert_ne!(ids_by_role["left"], ids_by_role["right"],);
 }

--- a/traceforge/tests/symbolic.rs
+++ b/traceforge/tests/symbolic.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "symbolic")]
+
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use traceforge::{

--- a/traceforge/tests/symbolic.rs
+++ b/traceforge/tests/symbolic.rs
@@ -70,7 +70,7 @@ fn symbolic_echo_transports_formula() {
         let x2: symbolic::SymExpr = recv_msg_block();
 
         assert_eq!(x1, x2);
-        symbolic::assert(x1.eq(x2));
+        symbolic::assert(x1.equals(x2));
 
         worker1.join().unwrap();
         worker2.join().unwrap();
@@ -90,7 +90,7 @@ fn symbolic_expr_supports_arithmetic_and_boolean_helpers() {
             .ge(4)
             .and(y.clone().le(10))
             .and(((x.clone() * 2) - 1).lt(y.clone().div(2) + 20))
-            .and(x.clone().sub(1).mult(3).ge(0))
+            .and(x.clone().sub(1).mul(3).ge(0))
             .implies((y / 2).ge(x % 3));
 
         symbolic::assume(guard);
@@ -106,7 +106,7 @@ fn symbolic_forward_revisit_explores_both_branch_outcomes() {
 
         let worker = thread::spawn(move || {
             let v: symbolic::SymExpr = recv_msg_block();
-            let even = symbolic::eval((v % 2).eq(symbolic::int_val(0)));
+            let even = symbolic::eval((v % 2).equals(symbolic::int_val(0)));
             send_msg(main_id, even);
         });
 
@@ -115,7 +115,7 @@ fn symbolic_forward_revisit_explores_both_branch_outcomes() {
 
         let even: bool = recv_msg_block();
         if even {
-            symbolic::assert((i % 2).eq(symbolic::int_val(0)));
+            symbolic::assert((i % 2).equals(symbolic::int_val(0)));
         }
 
         worker.join().unwrap();
@@ -142,7 +142,7 @@ fn buggy_control_flow_program() {
 
     let positive: bool = recv_msg_block();
     if positive {
-        symbolic::assert((i % 2).eq(symbolic::int_val(0)));
+        symbolic::assert((i % 2).equals(symbolic::int_val(0)));
     }
 
     worker.join().unwrap();
@@ -186,7 +186,7 @@ fn symbolic_receive_order_revisit_can_expose_order_sensitive_bug() {
         let first: symbolic::SymExpr = recv_msg_block();
         let second: symbolic::SymExpr = recv_msg_block();
 
-        symbolic::assert(second.eq(first + 1));
+        symbolic::assert(second.equals(first + 1));
 
         worker1.join().unwrap();
         worker2.join().unwrap();

--- a/traceforge/tests/symbolic.rs
+++ b/traceforge/tests/symbolic.rs
@@ -44,6 +44,88 @@ fn symbolic_backward_revisit_for_right_side_send_is_optimal() {
 }
 
 #[test]
+fn symbolic_forall_reflexive_equality_is_valid() {
+    let stats = verify(symbolic_config(), || {
+        let node = symbolic::uninterpreted_sort("Node");
+
+        symbolic::assert(symbolic::forall([("x", node)], |vars| {
+            let x = vars.get("x");
+            x.clone().equals(x)
+        }));
+    });
+
+    assert_eq!((stats.execs, stats.block), (1, 0));
+}
+
+#[test]
+fn symbolic_exists_constant_equality_is_satisfiable() {
+    let stats = verify(symbolic_config(), || {
+        let node = symbolic::uninterpreted_sort("Node");
+        let root = symbolic::constant("root", node.clone());
+
+        symbolic::assume(symbolic::exists([("x", node)], |vars| {
+            vars.get("x").equals(root)
+        }));
+    });
+
+    assert_eq!((stats.execs, stats.block), (1, 0));
+}
+
+#[test]
+fn symbolic_quantified_predicate_explores_both_branch_outcomes() {
+    let stats = verify(symbolic_config(), || {
+        let node = symbolic::uninterpreted_sort("Node");
+        let marked = symbolic::predicate("marked", &[node.clone()]);
+
+        let all_marked = symbolic::forall([("x", node)], |vars| marked.apply([vars.get("x")]));
+
+        if symbolic::eval(all_marked) {
+            // true branch
+        } else {
+            // false branch
+        }
+    });
+
+    assert_eq!((stats.execs, stats.block), (2, 0));
+}
+
+#[test]
+fn symbolic_quantifier_detects_invalid_assertion() {
+    let stats = verify(symbolic_keep_going_config(), || {
+        let node = symbolic::uninterpreted_sort("Node");
+        let marked = symbolic::predicate("marked", &[node.clone()]);
+        let root = symbolic::constant("root", node.clone());
+
+        symbolic::assert(
+            symbolic::forall([("x", node)], |vars| marked.apply([vars.get("x")]))
+                .and(marked.apply([root]).not()),
+        );
+    });
+
+    assert_eq!((stats.execs, stats.block), (0, 1));
+}
+
+#[test]
+fn symbolic_nested_quantifier_can_reference_outer_variable() {
+    let stats = verify(symbolic_config(), || {
+        let node = symbolic::uninterpreted_sort("Node");
+        let same = symbolic::predicate("same", &[node.clone(), node.clone()]);
+
+        symbolic::assert(symbolic::forall([("x", node.clone())], |outer| {
+            outer.exists([("y", node)], |inner| {
+                let x = inner.get("x");
+                let y = inner.get("y");
+                x.clone()
+                    .equals(y.clone())
+                    .and(same.apply([x, y]).implies(symbolic::bool_val(true)))
+            })
+        }));
+    });
+
+    assert_eq!((stats.execs, stats.block), (1, 0));
+}
+
+#[test]
 fn symbolic_echo_transports_formula() {
     let stats = verify(symbolic_config(), || {
         let main_id = thread::current_id();
@@ -193,7 +275,7 @@ fn symbolic_receive_order_revisit_can_expose_order_sensitive_bug() {
         worker2.join().unwrap();
     });
 
-    assert!(stats.block > 0,);
+    assert!(stats.block > 0);
 }
 
 #[test]

--- a/traceforge/tests/symbolic.rs
+++ b/traceforge/tests/symbolic.rs
@@ -96,7 +96,7 @@ fn symbolic_expr_supports_arithmetic_and_boolean_helpers() {
         symbolic::assume(guard);
     });
 
-    assert_eq!(stats.execs, 0);
+    assert_eq!(stats.execs, 1);
 }
 
 #[test]

--- a/traceforge/tests/symbolic.rs
+++ b/traceforge/tests/symbolic.rs
@@ -40,11 +40,7 @@ fn symbolic_backward_revisit_for_right_side_send_is_optimal() {
         worker.join().unwrap();
     });
 
-    assert_eq!(
-        (stats.execs, stats.block),
-        (3, 0),
-        "expected one false branch plus the two optimal true-branch receive outcomes, got {stats:?}"
-    );
+    assert_eq!((stats.execs, stats.block), (3, 0));
 }
 
 #[test]
@@ -133,10 +129,7 @@ fn symbolic_forward_revisit_explores_both_branch_outcomes() {
     });
 
     assert_eq!(stats.block, 0);
-    assert!(
-        stats.execs >= 2,
-        "expected true and false symbolic branch executions, got {stats:?}"
-    );
+    assert!(stats.execs >= 2,);
 }
 
 fn buggy_control_flow_program() {
@@ -169,10 +162,7 @@ fn symbolic_buggy_control_flow_panics_on_feasible_assert_failure() {
 fn symbolic_buggy_control_flow_records_failure_when_keep_going() {
     let stats = verify(symbolic_keep_going_config(), buggy_control_flow_program);
 
-    assert!(
-        stats.block > 0,
-        "expected a feasible assertion failure for i = 1, got {stats:?}"
-    );
+    assert!(stats.block > 0,);
 }
 
 #[test]
@@ -203,8 +193,105 @@ fn symbolic_receive_order_revisit_can_expose_order_sensitive_bug() {
         worker2.join().unwrap();
     });
 
-    assert!(
-        stats.block > 0,
-        "expected reversed receive order to violate second == first + 1, got {stats:?}"
-    );
+    assert!(stats.block > 0,);
+}
+
+#[test]
+fn symbolic_uninterpreted_sort_supports_equality() {
+    let stats = verify(symbolic_config(), || {
+        let node = symbolic::uninterpreted_sort("Node");
+        let x = symbolic::fresh(node.clone());
+        let y = symbolic::fresh(node);
+
+        symbolic::assert(x.clone().equals(y.clone()).implies(y.equals(x)));
+    });
+
+    assert_eq!((stats.execs, stats.block), (1, 0));
+}
+
+#[test]
+fn symbolic_uninterpreted_function_preserves_congruence() {
+    let stats = verify(symbolic_config(), || {
+        let node = symbolic::uninterpreted_sort("Node");
+        let parent = symbolic::uf("parent", &[node.clone()], node.clone());
+
+        let x = symbolic::fresh(node.clone());
+        let y = symbolic::fresh(node);
+
+        symbolic::assert(
+            x.clone()
+                .equals(y.clone())
+                .implies(parent.apply([x]).equals(parent.apply([y]))),
+        );
+    });
+
+    assert_eq!((stats.execs, stats.block), (1, 0));
+}
+
+#[test]
+fn symbolic_uninterpreted_predicate_explores_both_branch_outcomes() {
+    let stats = verify(symbolic_config(), || {
+        let node = symbolic::uninterpreted_sort("Node");
+        let marked = symbolic::predicate("marked", &[node.clone()]);
+        let x = symbolic::fresh(node);
+
+        if symbolic::eval(marked.apply([x])) {
+            // true branch
+        } else {
+            // false branch
+        }
+    });
+
+    assert_eq!((stats.execs, stats.block), (2, 0));
+}
+
+#[test]
+fn symbolic_uninterpreted_function_application_can_be_sent() {
+    let stats = verify(symbolic_config(), || {
+        let main_id = thread::current_id();
+        let node = symbolic::uninterpreted_sort("Node");
+        let parent = symbolic::uf("parent", &[node.clone()], node.clone());
+
+        let worker = thread::spawn(move || {
+            let v: symbolic::SymExpr = recv_msg_block();
+            send_msg(main_id, v);
+        });
+
+        let x = symbolic::fresh(node);
+        let px = parent.apply([x]);
+        send_msg(worker.thread().id(), px.clone());
+
+        let echoed: symbolic::SymExpr = recv_msg_block();
+        symbolic::assert(echoed.equals(px));
+
+        worker.join().unwrap();
+    });
+
+    assert_eq!((stats.execs, stats.block), (1, 0));
+}
+
+#[test]
+fn symbolic_backward_revisit_with_uninterpreted_predicate_is_optimal() {
+    let stats = verify(symbolic_ltr_config(), || {
+        let main_id = thread::current_id();
+        let node = symbolic::uninterpreted_sort("Node");
+        let ready = symbolic::predicate("ready", &[node.clone()]);
+        let ready_for_worker = ready.clone();
+
+        let worker = thread::spawn(move || {
+            let x = symbolic::fresh(node);
+            if symbolic::eval(ready_for_worker.apply([x.clone()])) {
+                send_msg(main_id, x);
+            }
+        });
+
+        let received: Option<symbolic::SymExpr> = recv_msg();
+        if let Some(x) = received {
+            symbolic::assert(ready.apply([x]));
+        }
+
+        worker.join().unwrap();
+    });
+
+    assert_eq!((stats.execs, stats.block), (3, 0));
 }

--- a/traceforge/tests/symbolic.rs
+++ b/traceforge/tests/symbolic.rs
@@ -427,3 +427,20 @@ fn symbolic_var_ids_are_stable_across_different_schedule_orders() {
     assert_eq!(ids_by_role["right"].len(), 1, "{ids_by_role:#?}");
     assert_ne!(ids_by_role["left"], ids_by_role["right"],);
 }
+
+#[test]
+fn symbolic_nested_quantifier_capture_of_outer_var_is_not_rebound() {
+    let stats = verify(symbolic_keep_going_config(), || {
+        symbolic::assert(symbolic::exists(
+            [("b", symbolic::SymSort::Bool)],
+            |outer| {
+                let b = outer.get("b");
+                outer.forall([("c", symbolic::SymSort::Bool)], |inner| {
+                    b.clone().equals(inner.get("c"))
+                })
+            },
+        ));
+    });
+
+    assert_eq!((stats.execs, stats.block), (0, 1));
+}

--- a/traceforge/tests/symbolic.rs
+++ b/traceforge/tests/symbolic.rs
@@ -96,7 +96,18 @@ fn symbolic_expr_supports_arithmetic_and_boolean_helpers() {
         symbolic::assume(guard);
     });
 
-    assert!(stats.execs > 0);
+    assert_eq!(stats.execs, 0);
+}
+
+#[test]
+fn symbolic_assume_unsatisfiable_blocks_execution() {
+    let stats = verify(symbolic_config(), || {
+        let x = symbolic::fresh_int();
+        symbolic::assume(x.clone().gt(0).and(x.lt(0)));
+    });
+
+    assert_eq!(stats.execs, 0);
+    assert_eq!(stats.block, 1);
 }
 
 #[test]

--- a/traceforge/tests/symbolic.rs
+++ b/traceforge/tests/symbolic.rs
@@ -1,0 +1,199 @@
+use traceforge::{
+    recv_msg, recv_msg_block, send_msg, symbolic, thread, verify, Config, SchedulePolicy,
+};
+
+fn symbolic_config() -> Config {
+    Config::builder().with_symbolic(true).build()
+}
+
+fn symbolic_ltr_config() -> Config {
+    Config::builder()
+        .with_policy(SchedulePolicy::LTR)
+        .with_symbolic(true)
+        .build()
+}
+
+fn symbolic_keep_going_config() -> Config {
+    Config::builder()
+        .with_symbolic(true)
+        .with_keep_going_after_error(true)
+        .build()
+}
+
+#[test]
+fn symbolic_backward_revisit_for_right_side_send_is_optimal() {
+    let stats = verify(symbolic_ltr_config(), || {
+        let main_id = thread::current_id();
+
+        let worker = thread::spawn(move || {
+            let x = symbolic::fresh_int();
+            if symbolic::eval(x.clone().gt(symbolic::int_val(0))) {
+                send_msg(main_id, x);
+            }
+        });
+
+        let received: Option<symbolic::SymExpr> = recv_msg();
+        if let Some(x) = received {
+            symbolic::assert(x.gt(symbolic::int_val(0)));
+        }
+
+        worker.join().unwrap();
+    });
+
+    assert_eq!(
+        (stats.execs, stats.block),
+        (3, 0),
+        "expected one false branch plus the two optimal true-branch receive outcomes, got {stats:?}"
+    );
+}
+
+#[test]
+fn symbolic_echo_transports_formula() {
+    let stats = verify(symbolic_config(), || {
+        let main_id = thread::current_id();
+
+        let worker1 = thread::spawn(move || {
+            let v: symbolic::SymExpr = recv_msg_block();
+            send_msg(main_id, v);
+        });
+
+        let worker2 = thread::spawn(move || {
+            let v: symbolic::SymExpr = recv_msg_block();
+            send_msg(main_id, v);
+        });
+
+        let b = symbolic::fresh_bool();
+        send_msg(worker1.thread().id(), b.clone());
+        send_msg(worker2.thread().id(), b);
+
+        let x1: symbolic::SymExpr = recv_msg_block();
+        let x2: symbolic::SymExpr = recv_msg_block();
+
+        assert_eq!(x1, x2);
+        symbolic::assert(x1.eq(x2));
+
+        worker1.join().unwrap();
+        worker2.join().unwrap();
+    });
+
+    assert_eq!(stats.block, 0);
+    assert!(stats.execs > 0);
+}
+
+#[test]
+fn symbolic_expr_supports_arithmetic_and_boolean_helpers() {
+    let stats = verify(symbolic_config(), || {
+        let x = symbolic::fresh_int();
+        let y = symbolic::fresh_int();
+        let guard = x
+            .clone()
+            .ge(4)
+            .and(y.clone().le(10))
+            .and(((x.clone() * 2) - 1).lt(y.clone().div(2) + 20))
+            .and(x.clone().sub(1).mult(3).ge(0))
+            .implies((y / 2).ge(x % 3));
+
+        symbolic::assume(guard);
+    });
+
+    assert!(stats.execs > 0);
+}
+
+#[test]
+fn symbolic_forward_revisit_explores_both_branch_outcomes() {
+    let stats = verify(symbolic_config(), || {
+        let main_id = thread::current_id();
+
+        let worker = thread::spawn(move || {
+            let v: symbolic::SymExpr = recv_msg_block();
+            let even = symbolic::eval((v % 2).eq(symbolic::int_val(0)));
+            send_msg(main_id, even);
+        });
+
+        let i = symbolic::fresh_int();
+        send_msg(worker.thread().id(), i.clone());
+
+        let even: bool = recv_msg_block();
+        if even {
+            symbolic::assert((i % 2).eq(symbolic::int_val(0)));
+        }
+
+        worker.join().unwrap();
+    });
+
+    assert_eq!(stats.block, 0);
+    assert!(
+        stats.execs >= 2,
+        "expected true and false symbolic branch executions, got {stats:?}"
+    );
+}
+
+fn buggy_control_flow_program() {
+    let main_id = thread::current_id();
+
+    let worker = thread::spawn(move || {
+        let v: symbolic::SymExpr = recv_msg_block();
+        let positive = symbolic::eval(v.gt(symbolic::int_val(0)));
+        send_msg(main_id, positive);
+    });
+
+    let i = symbolic::fresh_int();
+    send_msg(worker.thread().id(), i.clone());
+
+    let positive: bool = recv_msg_block();
+    if positive {
+        symbolic::assert((i % 2).eq(symbolic::int_val(0)));
+    }
+
+    worker.join().unwrap();
+}
+
+#[test]
+#[should_panic]
+fn symbolic_buggy_control_flow_panics_on_feasible_assert_failure() {
+    verify(symbolic_config(), buggy_control_flow_program);
+}
+
+#[test]
+fn symbolic_buggy_control_flow_records_failure_when_keep_going() {
+    let stats = verify(symbolic_keep_going_config(), buggy_control_flow_program);
+
+    assert!(
+        stats.block > 0,
+        "expected a feasible assertion failure for i = 1, got {stats:?}"
+    );
+}
+
+#[test]
+fn symbolic_receive_order_revisit_can_expose_order_sensitive_bug() {
+    let stats = verify(symbolic_keep_going_config(), || {
+        let main_id = thread::current_id();
+
+        let worker1 = thread::spawn(move || {
+            let x: symbolic::SymExpr = recv_msg_block();
+            send_msg(main_id, x);
+        });
+
+        let worker2 = thread::spawn(move || {
+            let y: symbolic::SymExpr = recv_msg_block();
+            send_msg(main_id, y);
+        });
+
+        let base = symbolic::fresh_int();
+        send_msg(worker1.thread().id(), base.clone());
+        send_msg(worker2.thread().id(), base + 1);
+
+        let first: symbolic::SymExpr = recv_msg_block();
+        let second: symbolic::SymExpr = recv_msg_block();
+
+        symbolic::assert(second.eq(first + 1));
+
+        worker1.join().unwrap();
+        worker2.join().unwrap();
+    });
+
+    assert!(
+        stats.block > 0,
+        "expected reversed receive order to violate second == first + 1, got {stats:?}"
+    );
+}


### PR DESCRIPTION
This introduces concolic execution support (ConDpor) for TraceForge.

The support is by default disabled and to be enabled using
```rust
Config::builder().with_symbolic(true).build()
```
When enabled, TraceForge records symbolic variables and symbolic constraint evaluations in the execution graph.
We rely on Z3 to check path feasibility, and uses those checks to guide forward and backward revisits.

## API

The symbolic API lives under `traceforge::symbolic`:
- `symbolic::fresh_int()` creates a fresh symbolic integer.
- `symbolic::fresh_bool()` creates a fresh symbolic boolean.
- `symbolic::eval(expr)` evaluates a symbolic boolean expression as a branch decision and schedules a forward revisit when both outcomes are feasible.
- `symbolic::assume(expr)` blocks the current execution when the assumption is infeasible.
- `symbolic::assert(expr)` reports a feasible assertion failure, or records it and keeps exploring when `with_keep_going_after_error(true)` is enabled.

Symbolic values are represented as `SymExpr`. Operations are defined directly on `SymExpr`, so expressions can be composed before being passed to `symbolic::eval`, `symbolic::assume`, or `symbolic::assert`.
Symbolic expressions support boolean operators, comparisons, and integer arithmetic, including `and`, `or`, `not`, `implies`, `eq`, `gt`, `ge`, `lt`, `le`, `+`, `-`, `*`, `/`, and `%`.

Support for other theories can be added incrementally as needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
