### PR TITLE
ci: build and test the symbolic feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --workspace --all-targets
+        run: cargo build --workspace --all-targets --features symbolic
 
       - name: Run tests
-        run: cargo test --workspace --all-targets
+        run: cargo test --workspace --all-targets --features symbolic


### PR DESCRIPTION
*Issue:* The workflow installs libz3-dev but ran cargo build/cargo test without --features symbolic. The symbolic example and tests) were therefore never compiled or run, and the symbolic-gated library code was never type-checked -> leaving the z3 install step effectively unused.

*Description of changes:*  Added cargo build --workspace --all-targets and cargo test  --workspace --all-targets --features symbolic

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
