### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/TraceForge/security/code-scanning/2](https://github.com/awslabs/TraceForge/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/test.yml`.  
Best single fix without changing functionality: set workflow-level permissions to read-only for repository contents, which is sufficient for `actions/checkout` and does not grant unnecessary write access.

**Where to change**
- File: `.github/workflows/test.yml`
- Insert directly after `name: Tests` (before `on:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
